### PR TITLE
Playback de pistas v1

### DIFF
--- a/app/src/main/java/com/android/harmoniatpi/data/audio/AudioMixerRepositoryImpl.kt
+++ b/app/src/main/java/com/android/harmoniatpi/data/audio/AudioMixerRepositoryImpl.kt
@@ -10,11 +10,13 @@ import com.android.harmoniatpi.data.audio.player.PcmAudioPlayer
 import com.android.harmoniatpi.data.audio.util.AudioConverter
 import com.android.harmoniatpi.di.TrackFactory
 import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.audio.Track
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -62,11 +64,15 @@ class AudioMixerRepositoryImpl @Inject constructor(
         get() = tracks.value.map { it.player as PcmAudioPlayer }
 
 
-    override fun play() {
-        masterPlaybackJob?.cancel()
+    override fun play(excludeTrackId: Long?) {
 
-        val validTracks = tracks.value.filter { it.hasAudio() }
-        if (validTracks.isEmpty()) {
+        masterPlaybackJob?.cancel()
+        val tracksToPlay = tracks.value.filter { it.hasAudio() && it.id != excludeTrackId && !it.isMuted() }
+
+        if (tracksToPlay.isEmpty()) {
+            if (tracks.value.any { it.hasAudio() }) {
+                startPlaybackTracking()
+            }
             tracksCompleted.value = true
             return
         }
@@ -74,10 +80,10 @@ class AudioMixerRepositoryImpl @Inject constructor(
         val globalStartMs = currentPlaybackMs.value
         completedCount.set(0)
         tracksCompleted.value = false
-        masterPlaybackJob = CoroutineScope(Dispatchers.IO).launch {
+        masterPlaybackJob = CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
             startPlaybackTracking()
 
-            validTracks.forEach { track ->
+            tracksToPlay.forEach { track ->
                 launch {
                     val delayMs = (track.startOffsetMs - globalStartMs).coerceAtLeast(0L)
                     val internalPlayPos = (globalStartMs - track.startOffsetMs).coerceAtLeast(0L)
@@ -89,11 +95,10 @@ class AudioMixerRepositoryImpl @Inject constructor(
                     if (isActive) {
                         track.setOnPlaybackCompletedCallback {
                             val count = completedCount.incrementAndGet()
-                            if (count >= validTracks.size) {
-                                stop() // Llama a stop para limpiar todo.
+                            if (count >= tracksToPlay.size) {
+                                stop()
                             }
                         }
-
                         track.play(internalPlayPos)
                     }
                 }
@@ -115,7 +120,7 @@ class AudioMixerRepositoryImpl @Inject constructor(
         tracksCompleted.value = true
     }
 
-    override fun createTrack() {
+    override fun createTrack(sourceType: AudioSourceType) {
         val id = System.currentTimeMillis()
         val file = File(context.filesDir, "$id.pcm")
 
@@ -127,7 +132,8 @@ class AudioMixerRepositoryImpl @Inject constructor(
         val track = trackFactory.create(
             folderPath = context.filesDir.absolutePath,
             existingFilePath = file.absolutePath,
-            idExist = id
+            idExist = id,
+            sourceType = sourceType
         )
 
         tracks.update { it + track }
@@ -206,25 +212,24 @@ class AudioMixerRepositoryImpl @Inject constructor(
                 return@withContext Result.failure(FileNotFoundException("Archivo de origen temporal no encontrado."))
             }
 
-            val track = trackFactory.create(context.filesDir.absolutePath)
+            val track = trackFactory.create(
+                folderPath = context.filesDir.absolutePath,
+                sourceType = AudioSourceType.INSTRUMENT
+            )
             val destinationFile = File(track.path)
 
             try {
                 val inputUri = Uri.fromFile(sourceFile)
-
                 audioConverter.convertToPcm(inputUri, destinationFile)
                     .onFailure { error ->
                         sourceFile.delete()
                         return@withContext Result.failure(error)
                     }
-
                 tracks.update { it + track }
-
                 sourceFile.delete()
-
                 return@withContext Result.success(Unit)
             } catch (e: Exception) {
-                Log.e(TAG, "Error importando/convirtiendo pista: ${e.message}", e)
+                Log.e("AudioMixer", "Error importando/convirtiendo pista: ${e.message}", e)
                 destinationFile.delete()
                 sourceFile.delete()
                 return@withContext Result.failure(e)
@@ -383,13 +388,13 @@ class AudioMixerRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun loadPcmTrack(file: File, id: Long) {
+    override suspend fun loadPcmTrack(file: File, id: Long, sourceType: AudioSourceType) {
         if (!file.exists()) {
             Log.e(TAG, "PCM file not found: ${file.absolutePath}")
             return
         }
 
-        val track = trackFactory.create(file.parent!!, file.absolutePath, id)
+        val track = trackFactory.create(file.parent!!, file.absolutePath, id, sourceType = sourceType)
         tracks.update { it + track }
         Log.i(TAG, "Track restored from PCM: ${file.name} with path ${track.path}")
     }

--- a/app/src/main/java/com/android/harmoniatpi/data/audio/record/AudioRecorderRepositoryImpl.kt
+++ b/app/src/main/java/com/android/harmoniatpi/data/audio/record/AudioRecorderRepositoryImpl.kt
@@ -9,13 +9,12 @@ import javax.inject.Inject
 /**
  * Repositorio para operaciones de grabación de audio. Utiliza un AudioRecorder para la grabación.
  */
-class AudioRecorderRepositoryImpl
-@Inject constructor(private val recorder: AudioRecorder) : AudioRecorderRepository {
+class AudioRecorderRepositoryImpl @Inject constructor(private val recorder: AudioRecorder) : AudioRecorderRepository {
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
-    override fun startRecording(outputFilePath: String): Result<Unit> {
+    override fun startRecording(outputFilePath: String, audioSource: Int): Result<Unit> {
         recorder.setOutputFile(outputFilePath)
-        return recorder.startRecording()
+        return recorder.startRecording(audioSource)
     }
 
     override fun stopRecording() = recorder.stopRecording()

--- a/app/src/main/java/com/android/harmoniatpi/data/audio/record/PcmAudioRecorder.kt
+++ b/app/src/main/java/com/android/harmoniatpi/data/audio/record/PcmAudioRecorder.kt
@@ -4,6 +4,9 @@ import android.Manifest
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.AutomaticGainControl
+import android.media.audiofx.NoiseSuppressor
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.android.harmoniatpi.domain.interfaces.AudioRecorder
@@ -38,7 +41,7 @@ class PcmAudioRecorder @Inject constructor() : AudioRecorder {
     }
 
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
-    override fun startRecording(): Result<Unit> {
+    override fun startRecording(audioSource: Int): Result<Unit> {
         Log.i(TAG, "Starting recording. Path: ${outputFile?.path}")
         if (recordingJob != null) {
             Log.w(TAG, "Recording already in progress")
@@ -46,13 +49,33 @@ class PcmAudioRecorder @Inject constructor() : AudioRecorder {
         }
 
         audioRecord = AudioRecord(
-            MediaRecorder.AudioSource.MIC, sampleRate, channelConfig, audioFormat, bufferSize
+            audioSource,
+            sampleRate,
+            channelConfig,
+            audioFormat,
+            bufferSize
         )
 
         if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
             audioRecord = null
             return Result.failure(IllegalStateException("Error initializing AudioRecord"))
         }
+
+        try {
+            val audioSessionId = audioRecord!!.audioSessionId
+            if (AutomaticGainControl.isAvailable()) {
+                AutomaticGainControl.create(audioSessionId)?.enabled = false
+            }
+            if (NoiseSuppressor.isAvailable()) {
+                NoiseSuppressor.create(audioSessionId)?.enabled = false
+            }
+            if (AcousticEchoCanceler.isAvailable()) {
+                AcousticEchoCanceler.create(audioSessionId)?.enabled = true
+            }
+        } catch (e: Exception) {
+            Log.e("PcmAudioRecorder", "Error configuring audio effects", e)
+        }
+
 
         audioRecord?.startRecording()
         Log.i(TAG, "Recording started")

--- a/app/src/main/java/com/android/harmoniatpi/di/TrackFactory.kt
+++ b/app/src/main/java/com/android/harmoniatpi/di/TrackFactory.kt
@@ -1,5 +1,6 @@
 package com.android.harmoniatpi.di
 
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.audio.Track
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -13,6 +14,7 @@ interface TrackFactory {
     fun create(
         @Assisted("folder") folderPath: String,
         @Assisted("existing") existingFilePath: String? = null,
-        @Assisted("id") idExist : Long? = null
+        @Assisted("id") idExist : Long? = null,
+        @Assisted("sourceType") sourceType: AudioSourceType
     ): Track
 }

--- a/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioMixerRepository.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioMixerRepository.kt
@@ -1,5 +1,6 @@
 package com.android.harmoniatpi.domain.interfaces
 
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.audio.Track
 import kotlinx.coroutines.flow.StateFlow
 import java.io.File
@@ -11,7 +12,7 @@ interface AudioMixerRepository {
     /**
      * Reproduce las pistas.
      */
-    fun play()
+    fun play(excludeTrackId: Long? = null)
 
     /**
      * Pausa la reproducción de las pistas.
@@ -26,7 +27,7 @@ interface AudioMixerRepository {
     /**
      * Crea una nueva pista.
      */
-    fun createTrack()
+    fun createTrack(sourceType: AudioSourceType)
 
     /**
      * Crea una nueva pista a partir de un archivo de audio existente.
@@ -104,7 +105,7 @@ interface AudioMixerRepository {
     fun seekTo(ms: Long)
 
 
-    suspend fun loadPcmTrack(file: File,id: Long)
+    suspend fun loadPcmTrack(file: File, id: Long, sourceType: AudioSourceType)
 
     fun clearAllTracks()
 }

--- a/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioRecorder.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioRecorder.kt
@@ -13,7 +13,7 @@ interface AudioRecorder {
     /**
      * Inicia la grabación de audio.
      */
-    fun startRecording(): Result<Unit>
+    fun startRecording(audioSource: Int): Result<Unit>
 
     /**
      * Para la grabación de audio.

--- a/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioRecorderRepository.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/interfaces/AudioRecorderRepository.kt
@@ -8,7 +8,7 @@ interface AudioRecorderRepository {
      * Inicia la grabación de audio.
      * @param outputFilePath Ruta del archivo de salida.
      */
-    fun startRecording(outputFilePath: String): Result<Unit>
+    fun startRecording(outputFilePath: String, audioSource: Int): Result<Unit>
 
     /**
      * Para la grabación de audio.

--- a/app/src/main/java/com/android/harmoniatpi/domain/model/audio/AudioSourceType.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/model/audio/AudioSourceType.kt
@@ -1,0 +1,6 @@
+package com.android.harmoniatpi.domain.model.audio
+
+enum class AudioSourceType {
+    VOICE,
+    INSTRUMENT
+}

--- a/app/src/main/java/com/android/harmoniatpi/domain/model/audio/Track.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/model/audio/Track.kt
@@ -16,6 +16,7 @@ class Track @AssistedInject constructor(
     @Assisted("folder") folderPath: String,
     @Assisted("existing") existingFilePath: String?,
     @Assisted("id") idExist: Long?,
+    @Assisted("sourceType") val sourceType: AudioSourceType,
     val player: AudioPlayer
 ) {
     val id = idExist ?: System.currentTimeMillis()

--- a/app/src/main/java/com/android/harmoniatpi/domain/model/project/AudioTrack.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/model/project/AudioTrack.kt
@@ -1,11 +1,13 @@
 package com.android.harmoniatpi.domain.model.project
 
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
 
 data class AudioTrack(
     val id: Long,
     val path: String,
     val title: String,
+    val sourceType: AudioSourceType,
     val selected: Boolean,
     val waveForm: List<Float>? = null,
     val durationMs: Long = 0L,
@@ -20,6 +22,7 @@ data class AudioTrack(
             path = path,
             title = title,
             selected = selected,
+            sourceType = sourceType,
             waveForm = waveForm,
             durationMs = durationMs,
             isUndoAvailable = isUndoAvailable,

--- a/app/src/main/java/com/android/harmoniatpi/domain/usecases/AddTrackUseCase.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/usecases/AddTrackUseCase.kt
@@ -1,10 +1,11 @@
 package com.android.harmoniatpi.domain.usecases
 
 import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import javax.inject.Inject
 
 class AddTrackUseCase @Inject constructor(private val mixer: AudioMixerRepository) {
-    operator fun invoke() {
-        mixer.createTrack()
+    operator fun invoke(sourceType: AudioSourceType) {
+        mixer.createTrack(sourceType)
     }
 }

--- a/app/src/main/java/com/android/harmoniatpi/domain/usecases/LoadProjectTrackUseCase.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/usecases/LoadProjectTrackUseCase.kt
@@ -1,6 +1,7 @@
 package com.android.harmoniatpi.domain.usecases
 
 import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import java.io.File
 import java.io.FileNotFoundException
 import javax.inject.Inject
@@ -15,14 +16,14 @@ class LoadProjectTrackUseCase @Inject constructor(
      * @param pcmFilePath Ruta absoluta del archivo PCM.
      * @return Result<Unit> indicando el éxito o fallo de la operación.
      */
-    suspend operator fun invoke(pcmFilePath: String, id: Long): Result<Unit> {
+    suspend operator fun invoke(pcmFilePath: String, id: Long, sourceType: AudioSourceType): Result<Unit> {
         return try {
             val file = File(pcmFilePath)
             if (!file.exists()) {
                 return Result.failure(FileNotFoundException("Archivo PCM no encontrado: $pcmFilePath"))
             }
 
-            mixer.loadPcmTrack(file, id)
+            mixer.loadPcmTrack(file, id,  sourceType)
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/android/harmoniatpi/domain/usecases/PlayAudioUseCase.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/usecases/PlayAudioUseCase.kt
@@ -4,5 +4,5 @@ import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
 import javax.inject.Inject
 
 class PlayAudioUseCase @Inject constructor(private val mixer: AudioMixerRepository) {
-    operator fun invoke() = mixer.play()
+    operator fun invoke(excludeTrackId: Long? = null) = mixer.play(excludeTrackId)
 }

--- a/app/src/main/java/com/android/harmoniatpi/domain/usecases/StartRecordingAudioUseCase.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/usecases/StartRecordingAudioUseCase.kt
@@ -7,5 +7,6 @@ import javax.inject.Inject
 class StartRecordingAudioUseCase @Inject constructor(
     private val audioRecorderRepository: AudioRecorderRepository
 ) {
-    operator fun invoke(outputFileName: String) = audioRecorderRepository.startRecording(outputFileName)
+    operator fun invoke(outputFileName: String, audioSource: Int) =
+        audioRecorderRepository.startRecording(outputFileName, audioSource)
 }

--- a/app/src/main/java/com/android/harmoniatpi/ui/components/TrackItem.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/components/TrackItem.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.harmoniatpi.R
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.ui.core.theme.HarmoniaTPITheme
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
 import kotlinx.coroutines.launch
@@ -438,7 +439,7 @@ private fun TrackPrev() {
 
     HarmoniaTPITheme(false) {
         TrackItem(
-            track = TrackUi(0, "", "Nombre", true, fakeWaveform, durationMs = 3000L, startOffsetMs = 1000L),
+            track = TrackUi(0, "", "Nombre", true, waveForm = fakeWaveform, durationMs = 3000L, startOffsetMs = 1000L, sourceType = AudioSourceType.INSTRUMENT),
             onClick = {},
             onDelete = {},
             onTrim = {},

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/ProjectManagementScreen.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/ProjectManagementScreen.kt
@@ -2,6 +2,7 @@ package com.android.harmoniatpi.ui.screens.projectManagementScreen
 
 import android.net.Uri
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -48,6 +49,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
@@ -58,6 +60,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.ui.components.ProyectControlButtonRow
 import com.android.harmoniatpi.ui.components.TrackItem
 import com.android.harmoniatpi.ui.components.TrimAudioDialog
@@ -75,7 +78,7 @@ fun ProjectManagementScreen(
     val state by viewModel.state.collectAsState()
     val sharedScrollState = rememberScrollState()
     var trackForTrimming by remember { mutableStateOf<TrackUi?>(null) }
-
+    val context = LocalContext.current
     val pickAudioLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
@@ -143,7 +146,7 @@ fun ProjectManagementScreen(
                         onDelete = { viewModel.deleteTrack() },
                         onTrim = {
                             if (track.waveForm.isNullOrEmpty() || track.durationMs < 50L) {
-                                // TODO: Usar Toast para feedback al usuario
+                                Toast.makeText(context, "La pista no tiene audio para recortar", Toast.LENGTH_SHORT).show()
                                 Log.d("Trim", "Pista sin audio o muy corta para recortar.")
                             } else {
                                 trackForTrimming = track
@@ -201,7 +204,9 @@ fun ProjectManagementScreen(
                 onSkipPrevious = { viewModel.stopPlaying() },
                 onPlay = { viewModel.play() },
                 onPause = { viewModel.pause() },
-                startRecording = { viewModel.startRecording() },
+                startRecording = {
+                    Toast.makeText(context, "Para una mejor calidad, usa auriculares.", Toast.LENGTH_LONG).show()
+                    viewModel.startRecording() },
                 stopRecording = { viewModel.stopRecording() },
                 isRecording = state.isRecording,
                 isPlaying = state.isPlaying,
@@ -214,37 +219,27 @@ fun ProjectManagementScreen(
                     sheetState = sheetState
                 ) {
                     Column(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp)
+                        Modifier.fillMaxWidth().padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Button(
-                            onClick = {
-                                showSheet = false
-                                viewModel.addNewTrack()
-                            },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text("Nueva pista")
+                        Text("Añadir Pista", style = MaterialTheme.typography.titleLarge)
+
+                        Button(onClick = {
+                            showSheet = false
+                            viewModel.addNewTrack(AudioSourceType.VOICE)
+                        }, modifier = Modifier.fillMaxWidth()) {
+                            Text("🎤 Grabar Voz (con cancelación de eco)")
                         }
-                        Spacer(Modifier.height(8.dp))
 
-                        Button(
-                            onClick = {
-                                pickAudioLauncher.launch("audio/*")
-                            },
-                            modifier = Modifier.fillMaxWidth()
-                        ) { Text("Abrir archivo") }
+                        Button(onClick = {
+                            showSheet = false
+                            viewModel.addNewTrack(AudioSourceType.INSTRUMENT)
+                        }, modifier = Modifier.fillMaxWidth()) {
+                            Text("🎸 Grabar Instrumento (alta fidelidad)")
+                        }
 
-                        Spacer(Modifier.height(8.dp))
-
-                        Button(
-                            onClick = {
-                                showSheet = false
-                            },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text("Biblioteca de colaboraciones")
+                        Button(onClick = { pickAudioLauncher.launch("audio/*") }, modifier = Modifier.fillMaxWidth()) {
+                            Text("📁 Importar desde archivo")
                         }
                     }
                 }

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/TrackUi.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/TrackUi.kt
@@ -1,5 +1,6 @@
 package com.android.harmoniatpi.ui.screens.projectManagementScreen.model
 
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.project.AudioTrack
 
 data class TrackUi(
@@ -7,19 +8,21 @@ data class TrackUi(
     val path: String,
     val title: String,
     val selected: Boolean,
+    val sourceType: AudioSourceType,
     val waveForm: List<Float>? = null,
     val durationMs: Long = 0L,
     val isUndoAvailable: Boolean = false,
     val isMuted: Boolean = false,
     val volume: Float = 1f,
     val startOffsetMs: Long = 0L
-){
+) {
     fun toAudioTrack(): AudioTrack {
         return AudioTrack(
             id = id,
             path = path,
             title = title,
             selected = selected,
+            sourceType = sourceType,
             waveForm = waveForm,
             durationMs = durationMs,
             isUndoAvailable = isUndoAvailable,

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/viewmodel/ProjectManagementScreenViewModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/viewmodel/ProjectManagementScreenViewModel.kt
@@ -1,11 +1,14 @@
 package com.android.harmoniatpi.ui.screens.projectManagementScreen.viewmodel
 
 import android.content.Context
+import android.media.MediaRecorder
 import android.net.Uri
 import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.harmoniatpi.domain.cache.HoloJamCache
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.usecases.AddTrackFromFileUseCase
 import com.android.harmoniatpi.domain.usecases.AddTrackUseCase
 import com.android.harmoniatpi.domain.usecases.DeleteTrackUseCase
@@ -73,81 +76,39 @@ class ProjectManagementScreenViewModel @Inject constructor(
     private val _state = MutableStateFlow(ProyectScreenUiState())
     private var selectedTrack: TrackUi? = null
     val state = _state.asStateFlow()
+    private val originalVolumes = mutableMapOf<Long, Float>()
+
 
     init {
-        val project = holoJamCache.currentProjectSelected
-        _state.update {
-            it.copy(currentProjectSelected = project)
-        }.apply {
-            Log.i("KlyxDevs", "currentProjectSelected: ${state.value.currentProjectSelected}")
-        }
-
-        viewModelScope.launch {
-            fetchTracks()
-            if (!project?.urlAudioTracks.isNullOrEmpty()) {
-                Log.i("KlyxDevs", " Restaurando pistas del proyecto guardado...")
-
-                loadProjectTrackUseCase.clearAllTracks()
-
-                val loadedTracks = project.urlAudioTracks.map { it.toTrackUi() }
-                _state.update { currentState ->
-                    currentState.copy(tracks = loadedTracks)
-                }
-
-                // Reinyectar las pistas en el motor de audio (AudioMixerRepository)
-                project.urlAudioTracks.forEach { audioTrack ->
-                    val path = audioTrack.path
-                    val file = File(path)
-
-                    if (file.exists()) {
-                        Log.i("KlyxDevs", " Archivo encontrado en $path — restaurando pista...")
-
-                        loadProjectTrackUseCase(path, audioTrack.id)
-                            .onSuccess {
-                                Log.i(
-                                    "KlyxDevs",
-                                    " Pista restaurada correctamente: ${audioTrack.id}"
-                                )
-                            }
-                            .onFailure { e ->
-                                Log.e(
-                                    "KlyxDevs",
-                                    " Error restaurando pista ${audioTrack.id}: ${e.message}"
-                                )
-                            }
-                    } else {
-                        Log.w(
-                            "KlyxDevs",
-                            " Archivo no encontrado para pista ${audioTrack.id}: $path"
-                        )
-                    }
-                }
-
-
-                delay(500)
-                _state.update { current ->
-                    val updatedTracks = current.tracks.map { trackUi ->
-                        val result = generateWaveform(trackUi.path)
-                        trackUi.copy(
-                            waveForm = result.waveform,
-                            durationMs = result.durationMs
-                        )
-                    }
-                    val timelineWidth = getUpdatedTimeline(updatedTracks)
-                    current.copy(tracks = updatedTracks, timelineWidth = timelineWidth)
-                }
-
-                Log.i("KlyxDevs", " Todas las pistas fueron restauradas y listas para reproducir.")
-            } else {
-                Log.i("KlyxDevs", " Proyecto sin pistas previas — iniciando flujo normal.")
-
-            }
-
-            checkIfTracksWherePlayed()
-        }
+        startPlaybackObserver()
         fetchTracks()
         checkIfTracksWherePlayed()
-        startPlaybackObserver()
+        loadProjectFromCache()
+    }
+
+    private fun loadProjectFromCache() {
+        val project = holoJamCache.currentProjectSelected
+        _state.update { it.copy(currentProjectSelected = project) }
+
+        if (project != null && !project.urlAudioTracks.isNullOrEmpty()) {
+            viewModelScope.launch {
+                Log.i("KlyxDevs", "Restaurando pistas del proyecto guardado...")
+                loadProjectTrackUseCase.clearAllTracks()
+
+                project.urlAudioTracks.forEach { audioTrack ->
+                    val file = File(audioTrack.path)
+                    if (file.exists()) {
+                        loadProjectTrackUseCase(audioTrack.path, audioTrack.id, audioTrack.sourceType)
+                            .onSuccess { Log.i("KlyxDevs", "Pista restaurada en el mixer: ${audioTrack.id}") }
+                            .onFailure { e -> Log.e("KlyxDevs", "Error restaurando pista ${audioTrack.id}: ${e.message}") }
+                    } else {
+                        Log.w("KlyxDevs", "Archivo no encontrado para pista ${audioTrack.id}: ${audioTrack.path}")
+                    }
+                }
+            }
+        } else {
+            Log.i("KlyxDevs", "Proyecto nuevo o sin pistas guardadas.")
+        }
     }
 
 
@@ -190,16 +151,33 @@ class ProjectManagementScreenViewModel @Inject constructor(
 
     fun startRecording() {
         selectedTrack = state.value.tracks.find { it.selected }
-        selectedTrack?.let { track ->
-            startRecordingAudio(track.path)
+        selectedTrack?.let { trackToRecord ->
+
+            originalVolumes.clear()
+            val tracksToPlay = state.value.tracks.filter { it.id != trackToRecord.id }
+
+            tracksToPlay.forEach { track ->
+                originalVolumes[track.id] = track.volume
+                setTrackVolumeUseCase(track.id, 0.03f)
+            }
+
+
+            val audioSource = if (trackToRecord.sourceType == AudioSourceType.VOICE) {
+                MediaRecorder.AudioSource.VOICE_COMMUNICATION
+            } else {
+                MediaRecorder.AudioSource.MIC
+            }
+
+            playAudio(excludeTrackId = trackToRecord.id)
+            _state.update { it.copy(isPlaying = true) }
+
+            startRecordingAudio(trackToRecord.path, audioSource)
                 .onSuccess {
-                    Log.i(TAG, "Grabación comenzada")
-                    _state.update {
-                        it.copy(isRecording = true)
-                    }
+                    _state.update { it.copy(isRecording = true) }
                 }
                 .onFailure {
-                    Log.e(TAG, "Error al comenzar la grabación", it)
+                    stopPlaying()
+                    restoreOriginalVolumes()
                 }
         }
     }
@@ -208,19 +186,23 @@ class ProjectManagementScreenViewModel @Inject constructor(
         stopRecordingAudio()
             .onSuccess {
                 Log.i(TAG, "Grabación detenida")
+                stopPlaying()
+                restoreOriginalVolumes()
 
-                selectedTrack?.let { track ->
+                selectedTrack?.let { recordedTrack ->
                     viewModelScope.launch {
-                        // update: guardamos el waveform
-                        val result = generateWaveform(track.path)
+                        val result = generateWaveform(recordedTrack.path)
                         _state.update { currentState ->
                             val updatedTracks = currentState.tracks.map { trackUi ->
-                                if (trackUi.id == track.id) trackUi.copy(
-                                    waveForm = result.waveform,
-                                    durationMs = result.durationMs
-                                ) else trackUi
+                                if (trackUi.id == recordedTrack.id) {
+                                    trackUi.copy(
+                                        waveForm = result.waveform,
+                                        durationMs = result.durationMs
+                                    )
+                                } else {
+                                    trackUi
+                                }
                             }
-
                             val timelineWidth = getUpdatedTimeline(updatedTracks)
                             currentState.copy(
                                 tracks = updatedTracks,
@@ -232,10 +214,16 @@ class ProjectManagementScreenViewModel @Inject constructor(
             }
             .onFailure {
                 Log.e(TAG, "Error al detener la grabación", it)
+                restoreOriginalVolumes()
             }
-        _state.update {
-            it.copy(isRecording = false)
+        _state.update { it.copy(isRecording = false) }
+    }
+
+    private fun restoreOriginalVolumes() {
+        originalVolumes.forEach { (trackId, volume) ->
+            setTrackVolumeUseCase(trackId, volume)
         }
+        originalVolumes.clear()
     }
 
     fun play() {
@@ -260,8 +248,8 @@ class ProjectManagementScreenViewModel @Inject constructor(
         }
     }
 
-    fun addNewTrack() {
-        addTrack()
+    fun addNewTrack(sourceType: AudioSourceType) {
+        addTrack(sourceType)
     }
 
     fun deleteTrack() {
@@ -293,14 +281,15 @@ class ProjectManagementScreenViewModel @Inject constructor(
                 addTrackFromFileUseCase(tempFile.absolutePath)
                     .onSuccess {
                         Log.i(TAG, "Pista importada y convertida exitosamente desde $uri")
+                        Toast.makeText(context, "Pista importada exitosamente", Toast.LENGTH_SHORT).show()
                     }
                     .onFailure { e ->
                         Log.e(TAG, "Error importando pista desde $uri: ${e.message}", e)
-                        // TODO: Mostrar Toast con error
+                        Toast.makeText(context, "Error al importar la pista", Toast.LENGTH_SHORT).show()
                     }
             } catch (e: Exception) {
                 Log.e(TAG, "Error resolviendo o copiando archivo de origen: ${e.message}", e)
-                // TODO: Mostrar Toast con error
+                Toast.makeText(context, "Error al procesar el archivo", Toast.LENGTH_SHORT).show()
             } finally {
                 tempFile.delete()
             }
@@ -325,11 +314,13 @@ class ProjectManagementScreenViewModel @Inject constructor(
         viewModelScope.launch {
             trimAudioTrack(trackId, startMs, endMs)
                 .onSuccess {
+                    Toast.makeText(context, "Pista recortada", Toast.LENGTH_SHORT).show()
                     Log.i(TAG, "Audio trim successful for track $trackId")
                     updateTrackUiAfterModification(trackId)
                 }
                 .onFailure {
                     Log.e(TAG, "Error trimming audio for track $trackId", it)
+                    Toast.makeText(context, "Error al recortar la pista", Toast.LENGTH_SHORT).show()
                 }
         }
     }
@@ -340,9 +331,11 @@ class ProjectManagementScreenViewModel @Inject constructor(
                 .onSuccess {
                     Log.i(TAG, "Undo trim successful for track $trackId")
                     updateTrackUiAfterModification(trackId)
+                    Toast.makeText(context, "Recorte deshecho", Toast.LENGTH_SHORT).show()
                 }
                 .onFailure { e ->
                     Log.e(TAG, "Error undoing trim for track $trackId", e)
+                    Toast.makeText(context, "No se pudo deshacer el recorte", Toast.LENGTH_SHORT).show()
                     updateTrackUiAfterModification(trackId) // Forzar actualizacion si falló
                 }
         }
@@ -469,41 +462,29 @@ class ProjectManagementScreenViewModel @Inject constructor(
     private fun fetchTracks() {
         viewModelScope.launch {
             getTracks().collect { domainTracks ->
-                val currentUiTracks = _state.value.tracks
-                _state.update { currentState ->
-                    val updatedTracks = domainTracks.map { domainTrack ->
-                        val path = domainTrack.path
-                        val originalPath = path.replace(".pcm", ".pcm.original")
-                        val isUndoAvailable = File(originalPath).exists()
-                        val result = generateWaveform(path)
-                        val offset = domainTrack.startOffsetMs
+                val savedTracks = _state.value.currentProjectSelected?.urlAudioTracks ?: emptyList()
 
-                        // determina si es una pista existente o nueva
-                        currentUiTracks.find { it.id == domainTrack.id }?.copy(
-                            id = domainTrack.id,
-                            path = domainTrack.path,
-                            waveForm = result.waveform,
-                            durationMs = result.durationMs,
-                            isUndoAvailable = isUndoAvailable,
-                            startOffsetMs = offset // Usar el offset
-                        ) ?: TrackUi(
-                            title = "Voz",
-                            selected = false,
-                            id = domainTrack.id,
-                            path = domainTrack.path,
-                            waveForm = result.waveform,
-                            durationMs = result.durationMs,
-                            isUndoAvailable = isUndoAvailable,
-                            startOffsetMs = offset // Inicializar con offset
-                        )
-                    }
-                    val timelineWidth = getUpdatedTimeline(updatedTracks)
+                val updatedTracks = domainTracks.map { domainTrack ->
+                    val savedTrack = savedTracks.find { it.id == domainTrack.id }
+                    val title = if (domainTrack.sourceType == AudioSourceType.VOICE) "Voz" else "Instrumento"
 
-                    currentState.copy(
-                        tracks = updatedTracks,
-                        timelineWidth = timelineWidth
+                    TrackUi(
+                        id = domainTrack.id,
+                        path = domainTrack.path,
+                        title = savedTrack?.title ?: title,
+                        selected = state.value.tracks.find { it.id == domainTrack.id }?.selected ?: false,
+                        sourceType = domainTrack.sourceType,
+                        waveForm = savedTrack?.waveForm ?: generateWaveform(domainTrack.path).waveform,
+                        durationMs = savedTrack?.durationMs ?: generateWaveform(domainTrack.path).durationMs,
+                        isUndoAvailable = File(domainTrack.originalPath).exists(),
+                        startOffsetMs = savedTrack?.startOffsetMs ?: domainTrack.startOffsetMs,
+                        isMuted = savedTrack?.isMuted ?: domainTrack.isMuted(),
+                        volume = savedTrack?.volume ?: domainTrack.getVolume()
                     )
                 }
+
+                val timelineWidth = getUpdatedTimeline(updatedTracks)
+                _state.update { it.copy(tracks = updatedTracks, timelineWidth = timelineWidth) }
             }
         }
     }


### PR DESCRIPTION
# **Playback V1**

## **El usuario puede grabar sus pistas escuchando las otras pistas como guía a un volumen del 5%.**

-Puede elegir cuales quiere escuchar en el playback y cuales no (muteándolas).
-Se modificaron los AudioMixer y AudioRecorder para esto.
-Nuevo parámetro del track, audioSource.
-Se modificó la clase Track, así como también su factory y el modelo TrackUI, donde se incluye la fuente de audio (posteriormente será mejorada y ampliada a más instrumentos).
-Se implementa la cancelación de ruido para voz de forma nativa.
-Se agregaron Toasts informativos en `ProjectManagementScreen.kt` y en `ProjectManagementScreenViewModel.kt`

-Se refactorizó el código del `ProjectManagementScreenViewModel.kt` para mejorar las funcionalidades de recording, stop, fetch tracks y se limpió el init manteniendo la lógica (método nuevo `loadProjectFromCache()`).