### PR TITLE
Refactor: Se implementa BottomSheet para opciones de pista

### DIFF
--- a/app/src/main/java/com/android/harmoniatpi/ui/components/TrackItem.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/components/TrackItem.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -48,7 +47,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -74,6 +72,7 @@ import androidx.compose.ui.unit.dp
 import com.android.harmoniatpi.R
 import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.ui.core.theme.HarmoniaTPITheme
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.BottomSheetContent
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -101,8 +100,8 @@ fun TrackItem(
     modifier: Modifier = Modifier,
     timelineWidth: Int,
     msPerDpScale: Float,
-    mostrarFuturo: () -> Unit,
-) {
+    onShowBottomSheet: (BottomSheetContent) -> Unit,
+    ) {
     var showOptions by remember { mutableStateOf(false) }
 
     val infiniteTransition = rememberInfiniteTransition(label = "")
@@ -203,8 +202,8 @@ fun TrackItem(
                     onUndoEffect = onUndoEffect,
                     isUndoEffectAvailable = isUndoEffectAvailable,
                     isSelectionActive = isSelectionActive,
-                    mostrarFuturo = mostrarFuturo
-
+                    track = track,
+                    onShowBottomSheet = onShowBottomSheet,
                 )
             }
         }
@@ -276,7 +275,6 @@ fun TrackItem(
 
 @Composable
 private fun TrackOptionsMenu(
-    mostrarFuturo: () -> Unit,
     visible: Boolean,
     onDismiss: () -> Unit,
     onDelete: () -> Unit,
@@ -290,11 +288,58 @@ private fun TrackOptionsMenu(
     onUndoEffect: () -> Unit,
     isUndoEffectAvailable: Boolean,
     isSelectionActive: Boolean,
-    modifier: Modifier = Modifier
+    track: TrackUi,
+    onShowBottomSheet: (BottomSheetContent) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     DropdownMenu(
         expanded = visible, onDismissRequest = onDismiss, modifier = modifier
     ) {
+        DropdownMenuItem(
+            text = {
+                Text(text = "Renombrar")
+            },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.edit_icon),
+                    contentDescription = "Renombrar"
+                )
+            },
+            onClick = {onShowBottomSheet(BottomSheetContent.RenameTrack(track))}
+        )
+
+        DropdownMenuItem(
+            text = {
+                Text(text = "Volumen")
+            },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.mix_icon),
+                    contentDescription = "Volumen"
+                )
+            },
+            onClick = {
+                //En futuro llamar a -> onShowBottomSheet(BottomSheetContent.EditVolume(track))
+                onShowBottomSheet(BottomSheetContent.InDevelopment)
+                onDismiss()
+            }
+        )
+
+        DropdownMenuItem(
+            text = {
+                Text(text = "Paneo")
+            },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.pan_icon),
+                    contentDescription = "Paneo"
+                )
+            },
+            onClick = {
+                onShowBottomSheet(BottomSheetContent.InDevelopment)
+                onDismiss()
+            }
+        )
 
         DropdownMenuItem(
             text = { Text(text = "Copiar") },
@@ -326,8 +371,6 @@ private fun TrackOptionsMenu(
             enabled = isSelectionActive
         )
 
-
-
         DropdownMenuItem(
             text = { Text(text = "Efectos") },
             leadingIcon = {
@@ -341,8 +384,6 @@ private fun TrackOptionsMenu(
                 onShowEffects()
             }
         )
-
-
 
         DropdownMenuItem(
             text = {
@@ -361,43 +402,6 @@ private fun TrackOptionsMenu(
         )
 
 
-        DropdownMenuItem(
-            text = {
-                Text(text = "Volumen")
-            },
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(R.drawable.mix_icon),
-                    contentDescription = "Volumen"
-                )
-            },
-            onClick = {mostrarFuturo()}
-        )
-        DropdownMenuItem(
-            text = {
-                Text(text = "Paneo")
-            },
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(R.drawable.pan_icon),
-                    contentDescription = "Paneo"
-                )
-            },
-            onClick = {mostrarFuturo()}
-        )
-
-        DropdownMenuItem(
-            text = {
-                Text(text = "Editar")
-            },
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(R.drawable.edit_icon),
-                    contentDescription = "Editar"
-                )
-            },
-            onClick = {mostrarFuturo()}
-        )
 
         if (isUndoAvailable) {
             DropdownMenuItem(
@@ -597,9 +601,10 @@ fun DbWaveform(
                         handleStartPx = newPos
                     },
                     onDragStopped = {
-                        val startMs = (handleStartPx / density.density * msPerDpScale).coerceAtLeast(
-                            0f
-                        ).toLong()
+                        val startMs =
+                            (handleStartPx / density.density * msPerDpScale).coerceAtLeast(
+                                0f
+                            ).toLong()
                         val endMs = (handleEndPx / density.density * msPerDpScale).coerceAtMost(
                             maxDurationMs.toFloat()
                         ).toLong()
@@ -637,9 +642,10 @@ fun DbWaveform(
                     },
                     onDragStopped = {
 
-                        val startMs = (handleStartPx / density.density * msPerDpScale).coerceAtLeast(
-                            0f
-                        ).toLong()
+                        val startMs =
+                            (handleStartPx / density.density * msPerDpScale).coerceAtLeast(
+                                0f
+                            ).toLong()
                         val endMs = (handleEndPx / density.density * msPerDpScale).coerceAtMost(
                             maxDurationMs.toFloat()
                         ).toLong()
@@ -697,7 +703,7 @@ private fun TrackPrev() {
             onUndoEffect = {},
             isSelectionActive = false,
             msPerDpScale = 0F,
-            mostrarFuturo = {}
+            onShowBottomSheet = {}
         )
     }
 }

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/ProjectManagementScreen.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/ProjectManagementScreen.kt
@@ -10,28 +10,17 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ContentPaste
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material.icons.filled.ZoomOut
 import androidx.compose.material3.Card
@@ -57,20 +46,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -83,6 +63,11 @@ import com.android.harmoniatpi.ui.components.ShowConfirmationDialog
 import com.android.harmoniatpi.ui.components.TimelineHeader
 import com.android.harmoniatpi.ui.components.TrackItem
 import com.android.harmoniatpi.ui.components.TrimAudioDialog
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.components.AddTrackSheetContent
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.components.EmptyProjectMessage
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.components.InDevelopmentSheetContent
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.components.RenameTrackSheetContent
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.BottomSheetContent
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.viewmodel.ProjectManagementScreenViewModel
 import kotlinx.coroutines.launch
@@ -94,9 +79,6 @@ fun ProjectManagementScreen(
     viewModel: ProjectManagementScreenViewModel = hiltViewModel(),
     onBack: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState()
-    var showSheet by remember { mutableStateOf(false) }
-    var mostrarFuturo by remember { mutableStateOf(false) }
     val state by viewModel.state.collectAsState()
     val sharedScrollState = rememberScrollState()
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -108,8 +90,6 @@ fun ProjectManagementScreen(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
-            mostrarFuturo = false
-            showSheet = false
             viewModel.importTrackFromFile(it)
         }
     }
@@ -117,9 +97,12 @@ fun ProjectManagementScreen(
     val density = LocalDensity.current
     LaunchedEffect(state.currentPlaybackMs) {
         if (state.currentPlaybackMs > 0 && sharedScrollState.maxValue > 0 && state.isPlaying) {
-            val playbackPx = with(density) { (state.currentPlaybackMs / state.msPerDpScale).dp.toPx() }
-            val screenWidthPx = with(density) { 300.dp.toPx() } // Ancho aprox. de la pantalla visible
-            val targetScrollPosition = (playbackPx - screenWidthPx / 3).coerceAtLeast(0f).roundToInt()
+            val playbackPx =
+                with(density) { (state.currentPlaybackMs / state.msPerDpScale).dp.toPx() }
+            val screenWidthPx =
+                with(density) { 300.dp.toPx() } // Ancho aprox. de la pantalla visible
+            val targetScrollPosition =
+                (playbackPx - screenWidthPx / 3).coerceAtLeast(0f).roundToInt()
 
             if (targetScrollPosition > sharedScrollState.value && (targetScrollPosition - sharedScrollState.value) > 10) {
                 sharedScrollState.animateScrollTo(targetScrollPosition)
@@ -127,13 +110,10 @@ fun ProjectManagementScreen(
         }
     }
 
-
     BackHandler {
         viewModel.updateCurrentProjectWithTracks()
         onBack()
     }
-
-
 
     if (showDeleteDialog) {
         ShowConfirmationDialog(
@@ -149,7 +129,7 @@ fun ProjectManagementScreen(
         )
     }
 
-    if (state.importAudioLoading){
+    if (state.importAudioLoading) {
         Dialog(
             onDismissRequest = {},
             properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -165,6 +145,77 @@ fun ProjectManagementScreen(
             }
         }
     }
+
+    //  NUEVO BOTTOMSHEET
+    val activeSheet = state.activeSheetContent
+    if (activeSheet != null) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.hideBottomSheet() },
+            sheetState = sheetState
+        ) {
+            when (activeSheet) {
+                is BottomSheetContent.AddTrackMenu -> {
+
+                    AddTrackSheetContent(
+                        onImportFromFile = {
+                            viewModel.hideBottomSheet()
+                            pickAudioLauncher.launch("audio/*")
+                        },
+                        onRecordVoice = {
+                            viewModel.hideBottomSheet()
+                            viewModel.addNewTrack(AudioSourceType.VOICE)
+                        },
+                        onRecordInstrument = {
+                            viewModel.hideBottomSheet()
+                            viewModel.addNewTrack(AudioSourceType.INSTRUMENT)
+                        },
+                        onPasteTrack = {
+                            viewModel.hideBottomSheet()
+                            viewModel.pasteFromClipboard()
+                        },
+                        isClipboardFull = state.isClipboardFull
+                    )
+                }
+
+                is BottomSheetContent.EditVolume -> {
+                    /*// Nuevo Composable para el volumen
+                    VolumeSheetContent(
+                        track = activeSheet.track,
+                        onVolumeChange = { trackId, newVolume ->
+                            viewModel.setTrackVolume(trackId, newVolume)
+                        }
+                    )*/
+                    InDevelopmentSheetContent()
+
+                }
+
+                is BottomSheetContent.RenameTrack -> {
+                    RenameTrackSheetContent(
+                        track = activeSheet.track,
+                        onRename = { trackId, newName ->
+                            viewModel.renameTrack(trackId, newName)
+                            viewModel.hideBottomSheet()
+                        },
+                        onDismiss = {
+                            viewModel.hideBottomSheet()
+                        }
+                    )
+                }
+
+                is BottomSheetContent.InDevelopment -> {
+                    // Composable para "En desarrollo"
+                    InDevelopmentSheetContent()
+                }
+
+                is BottomSheetContent.TrackEffects -> {
+                    // ... el contenido para los efectos
+                }
+            }
+        }
+    }
+    // ----> FIN  BOTTOMSHEET <----
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -288,7 +339,7 @@ fun ProjectManagementScreen(
                             isSelectionActive = track.selectionStartMs != null &&
                                     (track.selectionEndMs == null || track.selectionEndMs > track.selectionStartMs),
                             msPerDpScale = state.msPerDpScale,
-                            mostrarFuturo = {mostrarFuturo = true}
+                            onShowBottomSheet = viewModel::showBottomSheet
                         )
                     }
                 }
@@ -303,7 +354,7 @@ fun ProjectManagementScreen(
 
             IconButton(
                 onClick = {
-                    showSheet = true
+                    viewModel.showBottomSheet(BottomSheetContent.AddTrackMenu)
                 },
                 modifier = Modifier
                     .padding(top = 16.dp, end = 32.dp)
@@ -324,11 +375,12 @@ fun ProjectManagementScreen(
             //Spacer(modifier = Modifier.weight(1f))
 
             ProyectControlButtonRow(
-                onSkipPrevious = { viewModel.stopPlaying()
+                onSkipPrevious = {
+                    viewModel.stopPlaying()
                     scope.launch {
                         sharedScrollState.animateScrollTo(0)
                     }
-                                 },
+                },
                 onPlay = { viewModel.play() },
                 onPause = { viewModel.pause() },
                 startRecording = {
@@ -345,97 +397,7 @@ fun ProjectManagementScreen(
                 modifier = Modifier,
             )
 
-            if (mostrarFuturo)
-            ModalBottomSheet(
-                onDismissRequest = { mostrarFuturo = false },
-                sheetState = sheetState,
-                containerColor = Color(0xFF121212), // Fondo oscuro del MBS
-                tonalElevation = 8.dp
-            ) {
-                Column( modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally){
 
-
-                    Text(
-                        text = "Funcion en desarrollo",
-                        style = MaterialTheme.typography.titleLarge.copy(color = Color.White),
-                        modifier = Modifier.padding(bottom = 8.dp),
-                        textAlign = TextAlign.Center
-                    )
-                }
-
-            }
-
-            if (showSheet) {
-                ModalBottomSheet(
-                    onDismissRequest = { showSheet = false },
-                    sheetState = sheetState,
-                    containerColor = Color(0xFF121212), // Fondo oscuro del MBS
-                    tonalElevation = 8.dp
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(20.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        Text(
-                            text = "Añadir pista",
-                            style = MaterialTheme.typography.titleLarge.copy(color = Color.White),
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-
-                        // Primera Fila - Pista de Voz y Pista de instrumento
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            OptionCard(
-                                title = "Grabar Voz\n(Cancelación\n de eco)",
-                                icon = Icons.Default.Mic,
-                                onClick = {
-                                    showSheet = false
-                                    viewModel.addNewTrack(AudioSourceType.VOICE)
-                                },
-                                modifier = Modifier.weight(1f)
-                            )
-                            OptionCard(
-                                title = "Grabar Instrumento\n(Hi-Fi)",
-                                icon = Icons.Default.MusicNote,
-                                onClick = {
-                                    showSheet = false
-                                    viewModel.addNewTrack(AudioSourceType.INSTRUMENT)
-                                },
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-
-                        // Segunda fila - Importar desde un archivo
-                        OptionCard(
-                            title = "Importar desde archivo",
-                            icon = Icons.Default.Folder,
-                            onClick = { pickAudioLauncher.launch("audio/*") },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-
-                        if (state.isClipboardFull) {
-                            OptionCard(
-                                title = "Pegar Pista",
-                                icon = Icons.Default.ContentPaste,
-                                onClick = {
-                                    showSheet = false
-                                    viewModel.pasteFromClipboard()
-                                },
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-
-                    }
-                }
-            }
         }
     }
 
@@ -468,124 +430,5 @@ fun ProjectManagementScreen(
     }
 }
 
-@Composable
-fun EmptyProjectMessage(modifier: Modifier = Modifier) {
-    // Usamos un mapa para definir el contenido del ícono en línea
-    val inlineContentMap = mapOf(
-        "add_icon" to InlineTextContent(
-            Placeholder(
-                width = 24.sp,
-                height = 24.sp,
-                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
-            )
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        color = MaterialTheme.colorScheme.primaryContainer,
-                        shape = CircleShape
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = "Agregar",
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(16.dp)
-                )
-            }
-        }
-    )
 
-    // Creamos el texto anotado
-    val annotatedText = buildAnnotatedString {
-        append("Presione ")
-        // Adjuntamos el ícono en línea usando su ID
-        appendInlineContent("add_icon", "[icono agregar]")
-        append(" para agregar una nueva pista para ")
-        withStyle(
-            style = SpanStyle(
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
-        ) {
-            append("grabar, insertar un archivo")
-        }
-        append(" o buscar en la biblioteca de sonidos.")
-    }
 
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 32.dp),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Box(
-            modifier = Modifier.padding(24.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = annotatedText,
-                inlineContent = inlineContentMap,
-                textAlign = TextAlign.Center,
-                fontSize = 18.sp,
-                lineHeight = 28.sp
-            )
-        }
-    }
-}
-
-// Composable para cada opción de la BottomSheet
-@Composable
-fun OptionCard(
-    title: String,
-    icon: ImageVector,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        onClick = onClick,
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = Color(0xFF1E1E1E)
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-        modifier = modifier
-            .height(100.dp)
-            .clip(RoundedCornerShape(16.dp))
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            contentAlignment = Alignment.CenterStart
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold
-                ),
-                modifier = Modifier.align(Alignment.CenterStart)
-            )
-            Spacer(modifier = Modifier.padding(240.dp))
-            // Icono circular flotante
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .size(36.dp)
-                    .background(Color(0xFFFF8117), CircleShape),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = Color.Black,
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/AddTrackSheetContent.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/AddTrackSheetContent.kt
@@ -1,0 +1,145 @@
+package com.android.harmoniatpi.ui.screens.projectManagementScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AddTrackSheetContent(
+    onImportFromFile: () -> Unit,
+    onRecordVoice: () -> Unit,
+    onRecordInstrument: () -> Unit,
+    onPasteTrack: () -> Unit,
+    isClipboardFull: Boolean
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Añadir pista",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        // Fila 1: Grabar Voz e Instrumento
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OptionCard(
+                title = "Grabar Voz\n(Cancelación\n de eco)",
+                icon = Icons.Default.Mic,
+                onClick = onRecordVoice,
+                modifier = Modifier.weight(1f)
+            )
+            OptionCard(
+                title = "Grabar Instrumento\n(Hi-Fi)",
+                icon = Icons.Default.MusicNote,
+                onClick = onRecordInstrument,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        // Fila 2: Importar desde archivo
+        OptionCard(
+            title = "Importar desde archivo",
+            icon = Icons.Default.Folder,
+            onClick = onImportFromFile,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // Fila 3: Pegar (Condicional)
+        if (isClipboardFull) {
+            OptionCard(
+                title = "Pegar Pista",
+                icon = Icons.Default.ContentPaste,
+                onClick = onPasteTrack,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+// Composable para cada opción de la BottomSheet
+@Composable
+fun OptionCard(
+    title: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0xFF1E1E1E)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        modifier = modifier
+            .height(100.dp)
+            .clip(RoundedCornerShape(16.dp))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold
+                ),
+                modifier = Modifier.align(Alignment.CenterStart)
+            )
+            Spacer(modifier = Modifier.padding(240.dp))
+            // Icono circular flotante
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .size(36.dp)
+                    .background(Color(0xFFFF8117), CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = Color.Black,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/EmptyProjectMessage.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/EmptyProjectMessage.kt
@@ -1,0 +1,100 @@
+package com.android.harmoniatpi.ui.screens.projectManagementScreen.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun EmptyProjectMessage(modifier: Modifier = Modifier) {
+    // Usamos un mapa para definir el contenido del ícono en línea
+    val inlineContentMap = mapOf(
+        "add_icon" to InlineTextContent(
+            Placeholder(
+                width = 24.sp,
+                height = 24.sp,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Agregar",
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    )
+
+    // Creamos el texto anotado
+    val annotatedText = buildAnnotatedString {
+        append("Presione ")
+        // Adjuntamos el ícono en línea usando su ID
+        appendInlineContent("add_icon", "[icono agregar]")
+        append(" para agregar una nueva pista para ")
+        withStyle(
+            style = SpanStyle(
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold
+            )
+        ) {
+            append("grabar, insertar un archivo")
+        }
+        append(" o buscar en la biblioteca de sonidos.")
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Box(
+            modifier = Modifier.padding(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = annotatedText,
+                inlineContent = inlineContentMap,
+                textAlign = TextAlign.Center,
+                fontSize = 18.sp,
+                lineHeight = 28.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/InDevelopmentSheetContent.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/InDevelopmentSheetContent.kt
@@ -1,0 +1,33 @@
+package com.android.harmoniatpi.ui.screens.projectManagementScreen.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun InDevelopmentSheetContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+
+        Text(
+            text = "Funcion en desarrollo",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 8.dp),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/RenameTrackSheetContent.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/components/RenameTrackSheetContent.kt
@@ -1,0 +1,122 @@
+package com.android.harmoniatpi.ui.screens.projectManagementScreen.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
+
+@Composable
+fun RenameTrackSheetContent(
+    track: TrackUi,
+    onRename: (trackId: Long, newName: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val maxLength = 11
+
+
+    var newName by remember { mutableStateOf(track.title) }
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // Para que el teclado se muestre automáticamente
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Renombrar Pista",
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        OutlinedTextField(
+            value = newName,
+            onValueChange = {
+                if(it.length <= maxLength){
+                newName = it }
+                },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
+            label = { Text("Nuevo nombre") },
+            leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    if (newName.isNotBlank()) {
+                        onRename(track.id, newName)
+                    }
+                }
+            ),
+            supportingText = {
+                Text(
+                    text = "${newName.length} / $maxLength",
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.End,
+                )
+            }
+
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedButton(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+            Spacer(Modifier.width(8.dp))
+            Button(
+                onClick = {
+                    keyboardController?.hide()
+                    onRename(track.id, newName)
+                },
+                enabled = newName.isNotBlank() && newName != track.title
+            ) {
+                Icon(Icons.Default.Done, contentDescription = "Guardar")
+                Spacer(Modifier.width(8.dp))
+                Text("Guardar")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/BottomSheetContent.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/BottomSheetContent.kt
@@ -1,0 +1,24 @@
+package com.android.harmoniatpi.ui.screens.projectManagementScreen.model
+
+/**
+ * Define los diferentes tipos de contenido que puede mostrar
+ * el ModalBottomSheet en la pantalla de gestión del proyecto.
+ */
+sealed class BottomSheetContent {
+    /**
+     * Para el menú principal de "Añadir pista"
+     */
+    object AddTrackMenu : BottomSheetContent()
+
+    /**
+     * Para las opciones de una pista específica
+     */
+    data class EditVolume(val track: TrackUi) : BottomSheetContent()
+    data class RenameTrack(val track: TrackUi) : BottomSheetContent()
+    data class TrackEffects(val track: TrackUi) : BottomSheetContent()
+
+    /**
+     * Para el diálogo de "En desarrollo"
+     */
+    object InDevelopment : BottomSheetContent()
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/ProyectScreenUiState.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/model/ProyectScreenUiState.kt
@@ -13,5 +13,6 @@ data class ProyectScreenUiState(
     val isClipboardFull: Boolean = false,
     val isRestoringTracks: Boolean = false,
     val msPerDpScale: Float = 10f,
-    val importAudioLoading : Boolean = false
+    val importAudioLoading : Boolean = false,
+    val activeSheetContent: BottomSheetContent? = null
 )

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/viewmodel/ProjectManagementScreenViewModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/projectManagementScreen/viewmodel/ProjectManagementScreenViewModel.kt
@@ -39,6 +39,7 @@ import com.android.harmoniatpi.domain.usecases.audioUseCases.UnMuteTrackUseCase
 import com.android.harmoniatpi.domain.usecases.audioUseCases.UndoEffectUseCase
 import com.android.harmoniatpi.domain.usecases.audioUseCases.UndoTrimUseCase
 import com.android.harmoniatpi.domain.usecases.roomUseCases.UpdateOrInsertProjectInDBUseCase
+import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.BottomSheetContent
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.ProyectScreenUiState
 import com.android.harmoniatpi.ui.screens.projectManagementScreen.model.TrackUi
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -816,6 +817,38 @@ class ProjectManagementScreenViewModel @Inject constructor(
         }
     }
 
+
+    /**
+     * Muestra un tipo específico de BottomSheet.
+     * @param content El contenido a mostrar (ej. AddTrackMenu, EditVolume, etc.)
+     */
+    fun showBottomSheet(content: BottomSheetContent) {
+        _state.update { it.copy(activeSheetContent = content) }
+    }
+
+    /**
+     * Oculta el BottomSheet actualmente activo.
+     */
+    fun hideBottomSheet() {
+        _state.update { it.copy(activeSheetContent = null) }
+    }
+
+    /**
+     * Renombra una pista.y actualiza el proyecto en la DB para persistencia inmediata.
+     */
+    fun renameTrack(trackId: Long, newName: String) {
+        _state.update { currentState ->
+            val updatedTracks = currentState.tracks.map { track ->
+                if (track.id == trackId) {
+                    track.copy(title = newName)
+                } else {
+                    track
+                }
+            }
+            currentState.copy(tracks = updatedTracks)
+        }
+        updateCurrentProjectWithTracks()
+    }
 
     private companion object {
         const val TAG = "AudioTestsViewModel"


### PR DESCRIPTION
Se ha refactorizado la pantalla de gestión de proyectos para reemplazar los menús y diálogos anteriores con un `ModalBottomSheet` genérico. Este cambio centraliza la gestión de las acciones del usuario, como añadir, renombrar, y ajustar el volumen o paneo de una pista.

Cambios específicos:
- **`ProjectManagementScreen`**: Se eliminó la lógica anterior para mostrar `ModalBottomSheet` y se reemplazó por un sistema unificado que responde al estado `activeSheetContent`.
- **`TrackItem`**: El menú de opciones de la pista ahora invoca a `onShowBottomSheet` con el contenido correspondiente (`RenameTrack`, `EditVolume`, etc.).
- **`ProjectManagementScreenViewModel`**: Se añadieron los métodos `showBottomSheet`, `hideBottomSheet` y `renameTrack` para controlar la visibilidad y el contenido del `BottomSheet`, y para manejar las acciones del usuario.
- **Nuevos componentes**: Se crearon los composables `AddTrackSheetContent`, `RenameTrackSheetContent` e `InDevelopmentSheetContent` para modularizar el contenido del `BottomSheet`.
- **Modelo de UI**: Se introdujo la clase `BottomSheetContent` para definir los diferentes estados y contenidos posibles del `BottomSheet`.