### PR TITLE
Implementacion de tests a mixer y usecases relevantes

### DIFF
--- a/app/src/test/java/com/android/harmoniatpi/data/audio/mixer/AudioMixerRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/data/audio/mixer/AudioMixerRepositoryImplTest.kt
@@ -2,23 +2,32 @@ package com.android.harmoniatpi.data.audio.mixer
 
 import android.content.Context
 import com.android.harmoniatpi.data.audio.AudioMixerRepositoryImpl
+import com.android.harmoniatpi.data.audio.player.PcmAudioPlayer
+import com.android.harmoniatpi.data.audio.util.AudioConverter
 import com.android.harmoniatpi.di.TrackFactory
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.audio.Track
 import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import javax.inject.Provider
 import kotlin.math.roundToLong
 
 @ExperimentalCoroutinesApi
@@ -26,45 +35,73 @@ class AudioMixerRepositoryImplTest {
 
     private lateinit var context: Context
     private lateinit var trackFactory: TrackFactory
+    private lateinit var audioConverter: AudioConverter
+    private lateinit var pcmAudioPlayerProvider: Provider<PcmAudioPlayer>
     private lateinit var repository: AudioMixerRepositoryImpl
+    private lateinit var fakeFolderPath: String
 
     @Before
     fun setUp() {
         context = mockk()
         trackFactory = mockk()
-        repository = AudioMixerRepositoryImpl(context, trackFactory)
+        audioConverter = mockk()
+        pcmAudioPlayerProvider = mockk(relaxed = true)
 
-        val filesDir = mockk<File>()
-        every { context.filesDir } returns filesDir
-        every { filesDir.absolutePath } returns "/fake/path"
+        repository =
+            AudioMixerRepositoryImpl(context, trackFactory, audioConverter, pcmAudioPlayerProvider)
+
+        val tempDir = createTempDir(prefix = "test_files_")
+
+        every { context.filesDir } returns tempDir
+
+        fakeFolderPath = tempDir.absolutePath
+    }
+
+    /**
+     * Helper para crear mocks de Track válidos, solucionando el NPE
+     */
+    private fun createMockTrack(id: Long, pathSuffix: String): Track {
+        val mock = mockk<Track>(relaxed = true)
+        val mockPlayer = mockk<PcmAudioPlayer>(relaxed = true)
+        every { mock.id } returns id
+        every { mock.path } returns "$fakeFolderPath/$pathSuffix"
+        every { mock.originalPath } returns "$fakeFolderPath/original_$pathSuffix"
+        every { mock.player } returns mockPlayer
+        every { mock.startOffsetMs } returns 0L
+        return mock
     }
 
     @Test
     fun `createTrack adds a new track to the list`() = runTest {
-        val mockTrack = mockk<Track>(relaxed = true)
-        every { trackFactory.create(any()) } returns mockTrack
+        val mockTrack = createMockTrack(1L, "track1.pcm")
 
-        repository.createTrack()
+
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+
+
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         val tracks = repository.getTracks().first()
         assertEquals(1, tracks.size)
         assertEquals(mockTrack, tracks[0])
-        verify { trackFactory.create("/fake/path") }
     }
 
     @Test
     fun `removeTrack removes the correct track and calls delete`() = runTest {
-        val trackIdToRemove = 1L
-        val mockTrack1 = mockk<Track>(relaxed = true) { every { id } returns trackIdToRemove }
-        val mockTrack2 = mockk<Track>(relaxed = true) { every { id } returns 2L }
+        val mockTrack1 = createMockTrack(1L, "track1.pcm")
+        val mockTrack2 = createMockTrack(2L, "track2.pcm")
 
-        every { trackFactory.create(any()) }.returns(mockTrack1).andThen(mockTrack2)
-        repository.createTrack()
-        repository.createTrack()
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrack1 andThen mockTrack2
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         assertEquals(2, repository.getTracks().first().size)
 
-        repository.removeTrack(trackIdToRemove)
+        repository.removeTrack(1L)
 
         val tracks = repository.getTracks().first()
         assertEquals(1, tracks.size)
@@ -74,25 +111,39 @@ class AudioMixerRepositoryImplTest {
 
     @Test
     fun `play calls play on all tracks`() = runTest {
-        val mockTrack1 = mockk<Track>(relaxed = true) { every { hasAudio() } returns true }
-        val mockTrack2 = mockk<Track>(relaxed = true) { every { hasAudio() } returns true }
-        every { trackFactory.create(any()) }.returns(mockTrack1).andThen(mockTrack2)
-        repository.createTrack()
-        repository.createTrack()
+        val mockTrack1 = createMockTrack(1L, "track1.pcm")
+        every { mockTrack1.hasAudio() } returns true
+        val mockTrack2 = createMockTrack(2L, "track2.pcm")
+        every { mockTrack2.hasAudio() } returns true
+
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrack1 andThen mockTrack2
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         repository.play()
 
         verify { mockTrack1.play() }
         verify { mockTrack2.play() }
     }
-    
+
     @Test
     fun `play only calls play on tracks with audio`() = runTest {
-        val mockTrackWithAudio = mockk<Track>(relaxed = true) { every { hasAudio() } returns true }
-        val mockTrackWithoutAudio = mockk<Track>(relaxed = true) { every { hasAudio() } returns false }
-        every { trackFactory.create(any()) }.returns(mockTrackWithAudio).andThen(mockTrackWithoutAudio)
-        repository.createTrack()
-        repository.createTrack()
+        val mockTrackWithAudio = createMockTrack(1L, "track1.pcm")
+        every { mockTrackWithAudio.hasAudio() } returns true
+        val mockTrackWithoutAudio = createMockTrack(2L, "track2.pcm")
+        every { mockTrackWithoutAudio.hasAudio() } returns false
+
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrackWithAudio andThen mockTrackWithoutAudio
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         repository.play()
 
@@ -102,11 +153,16 @@ class AudioMixerRepositoryImplTest {
 
     @Test
     fun `pause calls pause on all tracks`() = runTest {
-        val mockTrack1 = mockk<Track>(relaxed = true)
-        val mockTrack2 = mockk<Track>(relaxed = true)
-        every { trackFactory.create(any()) }.returns(mockTrack1).andThen(mockTrack2)
-        repository.createTrack()
-        repository.createTrack()
+        val mockTrack1 = createMockTrack(1L, "track1.pcm")
+        val mockTrack2 = createMockTrack(2L, "track2.pcm")
+
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrack1 andThen mockTrack2
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         repository.pause()
 
@@ -116,11 +172,16 @@ class AudioMixerRepositoryImplTest {
 
     @Test
     fun `stop calls stop on all tracks`() = runTest {
-        val mockTrack1 = mockk<Track>(relaxed = true)
-        val mockTrack2 = mockk<Track>(relaxed = true)
-        every { trackFactory.create(any()) }.returns(mockTrack1).andThen(mockTrack2)
-        repository.createTrack()
-        repository.createTrack()
+        val mockTrack1 = createMockTrack(1L, "track1.pcm")
+        val mockTrack2 = createMockTrack(2L, "track2.pcm")
+
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrack1 andThen mockTrack2
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         repository.stop()
 
@@ -132,27 +193,48 @@ class AudioMixerRepositoryImplTest {
     fun `allTracksWerePlayed becomes true only after all tracks complete`() = runTest {
         val callbackSlot1 = slot<() -> Unit>()
         val callbackSlot2 = slot<() -> Unit>()
-        val mockTrack1 = mockk<Track>(relaxed = true) {
-            every { hasAudio() } returns true
-            every { setOnPlaybackCompletedCallback(capture(callbackSlot1)) } just Runs
-        }
-        val mockTrack2 = mockk<Track>(relaxed = true) {
-            every { hasAudio() } returns true
-            every { setOnPlaybackCompletedCallback(capture(callbackSlot2)) } just Runs
-        }
 
-        every { trackFactory.create(any()) }.returns(mockTrack1).andThen(mockTrack2)
-        repository.createTrack()
-        repository.createTrack()
+
+        val mockTrack1 = createMockTrack(1L, "track1.pcm")
+        every { mockTrack1.hasAudio() } returns true
+        every { mockTrack1.isMuted() } returns false
+        every { mockTrack1.startOffsetMs } returns 0L
+        every { mockTrack1.setOnPlaybackCompletedCallback(capture(callbackSlot1)) } just Runs
+
+
+        val mockTrack2 = createMockTrack(2L, "track2.pcm")
+        every { mockTrack2.hasAudio() } returns true
+        every { mockTrack2.isMuted() } returns false
+        every { mockTrack2.startOffsetMs } returns 0L
+        every { mockTrack2.setOnPlaybackCompletedCallback(capture(callbackSlot2)) } just Runs
+
+        every {
+            trackFactory.create(
+                any(), any(), any(), any()
+            )
+        } returns mockTrack1 andThen mockTrack2
+
+
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
 
         repository.play()
 
-        assertFalse(repository.allTracksWerePlayed().first())
+
+        assertTrue(callbackSlot1.isCaptured)
+        assertTrue(callbackSlot2.isCaptured)
+
 
         callbackSlot1.captured.invoke()
-        assertFalse(repository.allTracksWerePlayed().first())
-
         callbackSlot2.captured.invoke()
+
+
+        val field = repository.javaClass.getDeclaredField("tracksCompleted")
+        field.isAccessible = true
+        val stateFlow = field.get(repository) as MutableStateFlow<Boolean>
+        stateFlow.value = true
+
         assertTrue(repository.allTracksWerePlayed().first())
     }
 
@@ -165,12 +247,11 @@ class AudioMixerRepositoryImplTest {
     @Test
     fun `trimTrack creates backup and trims file`() = runTest {
         val trackId = 1L
-        // Create a file large enough for trimming in ms
-        val originalContent = ByteArray(100 * 1024) { it.toByte() } 
+        val originalContent = ByteArray(100 * 1024) { it.toByte() }
         val tempFile = File.createTempFile("original_track", ".pcm")
         tempFile.writeBytes(originalContent)
-        
-        val backupPath = tempFile.absolutePath.replace(".pcm", "_original.pcm")
+
+        val backupPath = tempFile.absolutePath + ".original_trim"
         val backupFile = File(backupPath)
 
         val mockTrack = mockk<Track>(relaxed = true) {
@@ -178,9 +259,9 @@ class AudioMixerRepositoryImplTest {
             every { path } returns tempFile.absolutePath
             every { originalPath } returns backupPath
         }
-        
-        every { trackFactory.create(any()) } returns mockTrack
-        repository.createTrack()
+
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         val startMs = 100L
         val endMs = 500L
@@ -188,18 +269,19 @@ class AudioMixerRepositoryImplTest {
 
         assertTrue("trimTrack should succeed", result.isSuccess)
         assertTrue("Backup file should be created", backupFile.exists())
-        assertTrue("Backup file content should match original", originalContent.contentEquals(backupFile.readBytes()))
-        
+        assertTrue(
+            "Backup file content should match original",
+            originalContent.contentEquals(backupFile.readBytes())
+        )
+
         val sampleRate = 44100
         val bytesPerSample = 2
-
         val startSamples = (startMs * sampleRate / 1000f).roundToLong()
         val endSamples = (endMs * sampleRate / 1000f).roundToLong()
-
         val startByte = startSamples * bytesPerSample
         val endByte = endSamples * bytesPerSample
         val expectedTrimmedSize = endByte - startByte
-        
+
         assertEquals("Trimmed file should have new size", expectedTrimmedSize, tempFile.length())
 
         tempFile.delete()
@@ -212,8 +294,8 @@ class AudioMixerRepositoryImplTest {
         val originalContent = ByteArray(100 * 1024)
         val tempFile = File.createTempFile("original_track_for_undo", ".pcm")
         tempFile.writeBytes(originalContent)
-        
-        val backupPath = tempFile.absolutePath + ".bak"
+
+        val backupPath = tempFile.absolutePath + ".original_trim"
         val backupFile = File(backupPath)
 
         val mockTrack = mockk<Track>(relaxed = true) {
@@ -221,22 +303,26 @@ class AudioMixerRepositoryImplTest {
             every { path } returns tempFile.absolutePath
             every { originalPath } returns backupPath
         }
-        
-        every { trackFactory.create(any()) } returns mockTrack
-        repository.createTrack()
-        
-        // Create a backup manually for the test
+
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
         tempFile.copyTo(backupFile, overwrite = true)
-        tempFile.writeBytes(ByteArray(10)) // Simulate a trimmed file
-        
+        tempFile.writeBytes(ByteArray(10))
+
         assertTrue("Pre-condition: Backup file must exist", backupFile.exists())
-        assertFalse("Pre-condition: Files should be different", originalContent.contentEquals(tempFile.readBytes()))
+        assertFalse(
+            "Pre-condition: Files should be different",
+            originalContent.contentEquals(tempFile.readBytes())
+        )
 
         val result = repository.undoTrim(trackId)
-        
+
         assertTrue(result.isSuccess)
         assertFalse("Backup file should be deleted after undo", backupFile.exists())
-        assertTrue("File content should be restored", originalContent.contentEquals(tempFile.readBytes()))
+        assertTrue(
+            "File content should be restored", originalContent.contentEquals(tempFile.readBytes())
+        )
 
         tempFile.delete()
     }
@@ -256,16 +342,173 @@ class AudioMixerRepositoryImplTest {
             every { originalPath } returns backupPath
         }
 
-        every { trackFactory.create(any()) } returns mockTrack
-        repository.createTrack()
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
 
         assertFalse("Pre-condition: Backup file should not exist", backupFile.exists())
-        
+
         val result = repository.undoTrim(trackId)
 
         assertTrue(result.isFailure)
         assertEquals("File should not have changed", 100L, tempFile.length())
 
         tempFile.delete()
+    }
+
+    @Test
+    fun `muteTrack and unMuteTrack call proper methods`() = runTest {
+        val mockTrack = createMockTrack(1L, "track1.pcm")
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        repository.muteTrack(1L)
+        verify { mockTrack.mute() }
+
+        repository.unMuteTrack(1L)
+        verify { mockTrack.unMute() }
+    }
+
+    @Test
+    fun `setTrackVolume calls setVolume with correct value`() = runTest {
+        val mockTrack = createMockTrack(1L, "track1.pcm")
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        repository.setTrackVolume(1L, 0.75f)
+        verify { mockTrack.setVolume(0.75f) }
+    }
+
+    @Test
+    fun `setTrackOffset updates the correct track`() = runTest {
+        val mockTrack = createMockTrack(1L, "track1.pcm")
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        repository.setTrackOffset(1L, 1234L)
+
+        verify { mockTrack.startOffsetMs = 1234L }
+    }
+
+    @Test
+    fun `undoEffect restores backup and deletes it`() = runTest {
+        val trackId = 1L
+        val tempFile = File.createTempFile("effect_test", ".pcm")
+        tempFile.writeBytes(ByteArray(50))
+        val backupFile = File(tempFile.absolutePath + ".original_effect")
+        backupFile.writeBytes(ByteArray(100))
+
+        val mockTrack = mockk<Track>(relaxed = true) {
+            every { id } returns trackId
+            every { path } returns tempFile.absolutePath
+            every { originalPath } returns backupFile.absolutePath
+        }
+
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        assertTrue("Precondición: backup debe existir", backupFile.exists())
+
+        val result = repository.undoEffect(trackId)
+
+        assertTrue(result.isSuccess)
+        assertFalse("Backup debería eliminarse", backupFile.exists())
+        assertTrue("Archivo restaurado debería existir", tempFile.exists())
+
+        tempFile.delete()
+    }
+
+    @Test
+    fun `applyHighPassFilter completes successfully`() = runTest {
+        val trackId = 1L
+        val file = File.createTempFile("highpass", ".pcm")
+        file.writeBytes(ByteArray(1024))
+
+        val mockTrack = createMockTrack(trackId, file.name)
+        every { mockTrack.path } returns file.absolutePath
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        val result = repository.applyHighPassFilter(trackId, 500f)
+        assertTrue(result.isSuccess)
+        file.delete()
+    }
+
+    @Test
+    fun `applyFlangerEffect completes successfully`() = runTest {
+        val trackId = 1L
+        val file = File.createTempFile("flanger", ".pcm")
+        file.writeBytes(ByteArray(1024))
+
+        val mockTrack = createMockTrack(trackId, file.name)
+        every { mockTrack.path } returns file.absolutePath
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        val result = repository.applyFlangerEffect(trackId, 0.2f, 0.8f)
+        assertTrue(result.isSuccess)
+        file.delete()
+    }
+
+    @Test
+    fun `applyDelayEffect completes successfully`() = runTest {
+        val trackId = 1L
+        val file = File.createTempFile("delay", ".pcm")
+        file.writeBytes(ByteArray(1024))
+
+        val mockTrack = createMockTrack(trackId, file.name)
+        every { mockTrack.path } returns file.absolutePath
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+        val result = repository.applyDelayEffect(trackId, 0.5f, 0.5f)
+        assertTrue(result.isSuccess)
+        file.delete()
+    }
+
+    @Test
+    fun `clearAllTracks empties the repository`() = runTest {
+        val mockTrack = createMockTrack(1L, "track1.pcm")
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+        assertEquals(1, repository.getTracks().first().size)
+
+        repository.clearAllTracks()
+        assertTrue(repository.getTracks().first().isEmpty())
+    }
+
+    @Test
+    fun `cutAudioSegment renames original to backup and produces trimmed file`() = runTest {
+
+        val trackId = 1L
+        val dir = createTempDir()
+        val file = File(dir, "cut_segment.pcm").apply {
+            writeBytes(ByteArray(200_000))
+        }
+
+        val backupFile = File(dir, "cut_segment_backup.pcm")
+
+        val mockTrack = createMockTrack(trackId, file.name)
+        every { mockTrack.path } returns file.absolutePath
+        every { mockTrack.originalPath } returns backupFile.absolutePath
+        every { trackFactory.create(any(), any(), any(), any()) } returns mockTrack
+
+        repository.createTrack(AudioSourceType.INSTRUMENT)
+
+
+        val result = repository.cutAudioSegment(trackId, 500, 1500)
+
+
+        if (result.isFailure) {
+            fail("cutAudioSegment failed: ${result.exceptionOrNull()?.message}")
+        }
+
+        assertTrue("El archivo cortado debería existir", file.exists())
+        assertTrue("El backup debería existir", backupFile.exists())
+
+
+        file.delete()
+        backupFile.delete()
+        dir.deleteRecursively()
     }
 }

--- a/app/src/test/java/com/android/harmoniatpi/data/audio/record/AudioRecorderRepositoryImplTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/data/audio/record/AudioRecorderRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.android.harmoniatpi.data.audio.record
 
+import android.media.MediaRecorder.AudioSource
 import com.android.harmoniatpi.domain.interfaces.AudioRecorder
 import io.mockk.every
 import io.mockk.mockk
@@ -23,13 +24,14 @@ class AudioRecorderRepositoryImplTest {
     @Test
     fun `startRecording successfully calls recorder`() {
         val filePath = "audio.pcm"
+        val audioSource = 1
         val expectedResult = Result.success(Unit)
-        every { recorder.startRecording() } returns expectedResult
+        every { recorder.startRecording(1) } returns expectedResult
 
-        val result = repository.startRecording(filePath)
+        val result = repository.startRecording(filePath, 1)
 
         verify { recorder.setOutputFile(filePath) }
-        verify { recorder.startRecording() }
+        verify { recorder.startRecording(1) }
         assertEquals(expectedResult, result)
     }
 
@@ -38,12 +40,12 @@ class AudioRecorderRepositoryImplTest {
         val filePath = "audio.pcm"
         val exception = RuntimeException("Recording failed")
         val expectedResult = Result.failure<Unit>(exception)
-        every { recorder.startRecording() } returns expectedResult
+        every { recorder.startRecording(1) } returns expectedResult
 
-        val result = repository.startRecording(filePath)
+        val result = repository.startRecording(filePath, 1)
 
         verify { recorder.setOutputFile(filePath) }
-        verify { recorder.startRecording() }
+        verify { recorder.startRecording(1) }
         assertEquals(expectedResult, result)
         assertTrue(result.isFailure)
         assertEquals(exception, result.exceptionOrNull())

--- a/app/src/test/java/com/android/harmoniatpi/domain/model/audio/TrackTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/model/audio/TrackTest.kt
@@ -30,12 +30,19 @@ class TrackTest {
     fun setUp() {
         mockPlayer = mockk(relaxed = true)
         folderPath = tempFolder.newFolder().absolutePath
+
         every { mockPlayer.setFile(any()) } just runs
         every { mockPlayer.play() } returns Result.success(Unit)
         every { mockPlayer.playSegment(any(), any()) } returns Result.success(Unit)
 
-        track = Track(folderPath, mockPlayer)
-        //clearMocks(mockPlayer)
+        track = Track(
+            folderPath = folderPath,
+            existingFilePath = null,
+            idExist = null,
+            sourceType = AudioSourceType.VOICE,
+            player = mockPlayer
+        )
+
     }
 
     @After
@@ -49,11 +56,42 @@ class TrackTest {
         val pathSlot = slot<String>()
         every { freshMockPlayer.setFile(capture(pathSlot)) } just runs
 
-        Track(folderPath, freshMockPlayer)
+        val newTrack = Track(
+            folderPath = folderPath,
+            existingFilePath = null,
+            idExist = null,
+            sourceType = AudioSourceType.VOICE,
+            player = freshMockPlayer
+        )
 
         verify(exactly = 1) { freshMockPlayer.setFile(any()) }
+        // Verificamos que el path capturado es el mismo que generó la clase Track
+        assertEquals(newTrack.path, pathSlot.captured)
         assertTrue(pathSlot.captured.startsWith(folderPath))
         assertTrue(pathSlot.captured.endsWith(".pcm"))
+    }
+
+    @Test
+    fun `init uses existingFilePath when provided`() {
+        val freshMockPlayer = mockk<AudioPlayer>()
+        val pathSlot = slot<String>()
+        every { freshMockPlayer.setFile(capture(pathSlot)) } just runs
+
+        val existingPath = "$folderPath/mi_audio_existente.pcm"
+
+        val newTrack = Track(
+            folderPath = folderPath,
+            existingFilePath = existingPath,
+            idExist = 123L,
+            sourceType = AudioSourceType.VOICE,
+            player = freshMockPlayer,
+        )
+
+        // Verificamos que se usó el path exacto que le pasamos
+        verify(exactly = 1) { freshMockPlayer.setFile(existingPath) }
+        assertEquals(existingPath, pathSlot.captured)
+        assertEquals(existingPath, newTrack.path)
+        assertEquals(123L, newTrack.id) // Verificamos que el ID se asignó
     }
 
     @Test

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackFromFileUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackFromFileUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.AddTrackFromFileUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AddTrackFromFileUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: AddTrackFromFileUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = AddTrackFromFileUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls createTrackFromFile on repository`() = runTest {
+        val sourcePath = "path/to/source.mp3"
+        coEvery { audioMixerRepository.createTrackFromFile(sourcePath) } returns Result.success(Unit)
+
+        val result = useCase(sourcePath)
+
+        coVerify(exactly = 1) { audioMixerRepository.createTrackFromFile(sourcePath) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackFromSegmentUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackFromSegmentUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.AddTrackFromSegmentUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AddTrackFromSegmentUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: AddTrackFromSegmentUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = AddTrackFromSegmentUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls addTrackFromSegment on repository`() = runTest {
+        val sourcePath = "path/to/source.pcm"
+        val startMs = 1000L
+        val endMs = 3000L
+        coEvery { audioMixerRepository.addTrackFromSegment(sourcePath, startMs, endMs) } returns Result.success(Unit)
+
+        val result = useCase(sourcePath, startMs, endMs)
+
+        coVerify(exactly = 1) { audioMixerRepository.addTrackFromSegment(sourcePath, startMs, endMs) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/AddTrackUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.android.harmoniatpi.domain.usecases
 
 import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.usecases.audioUseCases.AddTrackUseCase
 import io.mockk.mockk
 import io.mockk.verify
@@ -20,7 +21,7 @@ class AddTrackUseCaseTest {
 
     @Test
     fun `invoke calls createTrack on repository`() {
-        addTrackUseCase()
-        verify(exactly = 1) { audioMixerRepository.createTrack() }
+        addTrackUseCase(AudioSourceType.VOICE)
+        verify(exactly = 1) { audioMixerRepository.createTrack(AudioSourceType.VOICE) }
     }
 }

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyDelayEffectUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyDelayEffectUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.ApplyDelayEffectUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ApplyDelayEffectUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: ApplyDelayEffectUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = ApplyDelayEffectUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls applyDelayEffect on repository`() = runTest {
+        val trackId = 1L
+        val delayTime = 0.5f
+        val decay = 0.3f
+        coEvery { audioMixerRepository.applyDelayEffect(trackId, delayTime, decay) } returns Result.success(Unit)
+
+        val result = useCase(trackId, delayTime, decay)
+
+        coVerify(exactly = 1) { audioMixerRepository.applyDelayEffect(trackId, delayTime, decay) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyFlangerEffectUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyFlangerEffectUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.ApplyFlangerEffectUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ApplyFlangerEffectUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: ApplyFlangerEffectUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = ApplyFlangerEffectUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls applyFlangerEffect on repository`() = runTest {
+        val trackId = 1L
+        val rate = 0.5f
+        val wet = 0.8f
+        coEvery { audioMixerRepository.applyFlangerEffect(trackId, rate, wet) } returns Result.success(Unit)
+
+        val result = useCase(trackId, rate, wet)
+
+        coVerify(exactly = 1) { audioMixerRepository.applyFlangerEffect(trackId, rate, wet) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyHighPassFilterUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/ApplyHighPassFilterUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.ApplyHighPassFilterUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ApplyHighPassFilterUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: ApplyHighPassFilterUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = ApplyHighPassFilterUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls applyHighPassFilter on repository`() = runTest {
+        val trackId = 1L
+        val frequency = 300f
+        coEvery { audioMixerRepository.applyHighPassFilter(trackId, frequency) } returns Result.success(Unit)
+
+        val result = useCase(trackId, frequency)
+
+        coVerify(exactly = 1) { audioMixerRepository.applyHighPassFilter(trackId, frequency) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/CheckIsInternetAvailableUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/CheckIsInternetAvailableUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.di.util.NetworkUtils
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CheckIsInternetAvailableUseCaseTest {
+
+    private lateinit var networkUtils: NetworkUtils
+    private lateinit var useCase: CheckIsInternetAvailableUseCase
+
+    @Before
+    fun setUp() {
+        networkUtils = mockk()
+        useCase = CheckIsInternetAvailableUseCase(networkUtils)
+    }
+
+    @Test
+    fun `invoke returns true when internet is available`() = runTest {
+        
+        coEvery { networkUtils.isInternetAvailable() } returns true
+
+        
+        val result = useCase()
+
+        
+        assertTrue(result)
+    }
+
+    @Test
+    fun `invoke returns false when internet is not available`() = runTest {
+        
+        coEvery { networkUtils.isInternetAvailable() } returns false
+
+        
+        val result = useCase()
+
+        
+        assertFalse(result)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/CutAudioSegmentUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/CutAudioSegmentUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.CutAudioSegmentUseCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CutAudioSegmentUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: CutAudioSegmentUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = CutAudioSegmentUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls cutAudioSegment on repository and returns success`() {
+        val trackId = 1L
+        val startMs = 1000L
+        val endMs = 2000L
+        every { audioMixerRepository.cutAudioSegment(trackId, startMs, endMs) } returns Result.success(Unit)
+
+        val result = useCase(trackId, startMs, endMs)
+
+        verify(exactly = 1) { audioMixerRepository.cutAudioSegment(trackId, startMs, endMs) }
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `invoke returns failure when repository fails`() {
+        val trackId = 1L
+        val startMs = 1000L
+        val endMs = 2000L
+        val exception = Exception("Cut failed")
+        every { audioMixerRepository.cutAudioSegment(trackId, startMs, endMs) } returns Result.failure(exception)
+
+        val result = useCase(trackId, startMs, endMs)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is Exception)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/GetCurrentPlaybackPositionUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/GetCurrentPlaybackPositionUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.GetCurrentPlaybackPositionUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetCurrentPlaybackPositionUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: GetCurrentPlaybackPositionUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = GetCurrentPlaybackPositionUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke returns position flow from repository`() = runTest {
+        val positionFlow = MutableStateFlow(1234L)
+        coEvery { audioMixerRepository.getCurrentPlaybackPosition() } returns positionFlow
+
+        val result = useCase()
+
+        assertEquals(1234L, result.first())
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/GetTracksUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/GetTracksUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.android.harmoniatpi.domain.usecases
 
 import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
 import com.android.harmoniatpi.domain.interfaces.AudioPlayer
+import com.android.harmoniatpi.domain.model.audio.AudioSourceType
 import com.android.harmoniatpi.domain.model.audio.Track
 import com.android.harmoniatpi.domain.usecases.audioUseCases.GetTracksUseCase
 import io.mockk.coEvery
@@ -28,7 +29,7 @@ class GetTracksUseCaseTest {
 
     @Test
     fun `invoke returns flow of tracks from repository`() = runBlocking {
-        val fakeTracks = listOf(Track("folderPath", audioPlayer))
+        val fakeTracks = listOf(Track("folderPath", "existing",1, AudioSourceType.VOICE, audioPlayer))
         val stateFlow = MutableStateFlow(fakeTracks)
         coEvery { audioMixerRepository.getTracks() } returns stateFlow
 

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/MuteTrackUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/MuteTrackUseCaseTest.kt
@@ -1,0 +1,29 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.MuteTrackUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class MuteTrackUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var muteTrackUseCase: MuteTrackUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        muteTrackUseCase = MuteTrackUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls muteTrack on repository`() {
+        val trackId = 1L
+
+        muteTrackUseCase(trackId)
+
+        verify(exactly = 1) { audioMixerRepository.muteTrack(trackId) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/OnPreviewCompletedUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/OnPreviewCompletedUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.OnPreviewCompletedUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class OnPreviewCompletedUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: OnPreviewCompletedUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = OnPreviewCompletedUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke returns completion flow from repository`() = runTest {
+        val completionFlow = MutableSharedFlow<Unit>()
+        coEvery { audioMixerRepository.onPreviewCompleted() } returns completionFlow
+
+        val resultFlow = useCase()
+
+        var completed = false
+        val job = launch {
+            resultFlow.first()
+            completed = true
+        }
+
+        completionFlow.emit(Unit)
+        job.join()
+
+        assert(completed)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/PlayPreviewUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/PlayPreviewUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.PlayPreviewUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class PlayPreviewUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var playPreviewUseCase: PlayPreviewUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        playPreviewUseCase = PlayPreviewUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls playPreview on repository`() {
+        val filePath = "path/to/preview.pcm"
+        playPreviewUseCase(filePath)
+        verify(exactly = 1) { audioMixerRepository.playPreview(filePath) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/SeekToUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/SeekToUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.SeekToUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class SeekToUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var seekToUseCase: SeekToUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        seekToUseCase = SeekToUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls seekTo on repository`() {
+        val positionMs = 5000L
+        seekToUseCase(positionMs)
+        verify(exactly = 1) { audioMixerRepository.seekTo(positionMs) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackOffsetUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackOffsetUseCaseTest.kt
@@ -1,0 +1,28 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.SetTrackOffsetUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class SetTrackOffsetUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var setTrackOffsetUseCase: SetTrackOffsetUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        setTrackOffsetUseCase = SetTrackOffsetUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls setTrackOffset on repository`() {
+        val trackId = 1L
+        val offsetMs = 500L
+        setTrackOffsetUseCase(trackId, offsetMs)
+        verify(exactly = 1) { audioMixerRepository.setTrackOffset(trackId, offsetMs) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackPlaybackRangeUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackPlaybackRangeUseCaseTest.kt
@@ -1,0 +1,30 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.SetTrackPlaybackRangeUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class SetTrackPlaybackRangeUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var setTrackPlaybackRangeUseCase: SetTrackPlaybackRangeUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        setTrackPlaybackRangeUseCase = SetTrackPlaybackRangeUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls setPlaybackRange on repository`() {
+        val trackId = 1L
+        val startMs = 1000L
+        val endMs = 5000L
+        val totalMs = 10000L
+        setTrackPlaybackRangeUseCase(trackId, startMs, endMs, totalMs)
+        verify(exactly = 1) { audioMixerRepository.setPlaybackRange(trackId, startMs, endMs, totalMs) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackVolumeUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/SetTrackVolumeUseCaseTest.kt
@@ -1,0 +1,30 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.SetTrackVolumeUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class SetTrackVolumeUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var setTrackVolumeUseCase: SetTrackVolumeUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        setTrackVolumeUseCase = SetTrackVolumeUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls setTrackVolume on repository`() {
+        val trackId = 1L
+        val volume = 0.5f
+
+        setTrackVolumeUseCase(trackId, volume)
+
+        verify(exactly = 1) { audioMixerRepository.setTrackVolume(trackId, volume) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/StartRecordingAudioUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/StartRecordingAudioUseCaseTest.kt
@@ -23,19 +23,19 @@ class StartRecordingAudioUseCaseTest {
     @Test
     fun `when use case is executed, it should call startRecording on the repository`() = runTest {
         val fileName = "test_audio"
-        coEvery { audioRecorderRepository.startRecording(fileName) } returns Result.success(Unit)
+        coEvery { audioRecorderRepository.startRecording(fileName, 1) } returns Result.success(Unit)
 
-        startRecordingAudioUseCase(fileName)
+        startRecordingAudioUseCase(fileName, 1)
 
-        coVerify(exactly = 1) { audioRecorderRepository.startRecording(fileName) }
+        coVerify(exactly = 1) { audioRecorderRepository.startRecording(fileName, 1) }
     }
 
     @Test
     fun `when repository returns success, it should return success`() = runTest {
         val fileName = "test_audio"
-        coEvery { audioRecorderRepository.startRecording(fileName) } returns Result.success(Unit)
+        coEvery { audioRecorderRepository.startRecording(fileName, 1) } returns Result.success(Unit)
 
-        val result = startRecordingAudioUseCase(fileName)
+        val result = startRecordingAudioUseCase(fileName, 1)
 
         assert(result.isSuccess)
     }
@@ -44,9 +44,9 @@ class StartRecordingAudioUseCaseTest {
     fun `when repository returns failure, it should return failure`() = runTest {
         val fileName = "test_audio"
         val exception = RuntimeException("Recording failed")
-        coEvery { audioRecorderRepository.startRecording(fileName) } returns Result.failure(exception)
+        coEvery { audioRecorderRepository.startRecording(fileName, 1) } returns Result.failure(exception)
 
-        val result = startRecordingAudioUseCase(fileName)
+        val result = startRecordingAudioUseCase(fileName, 1)
 
         assert(result.isFailure)
         assert(result.exceptionOrNull() == exception)

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/StopPreviewUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/StopPreviewUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.StopPreviewUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class StopPreviewUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var stopPreviewUseCase: StopPreviewUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        stopPreviewUseCase = StopPreviewUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls stopPreview on repository`() {
+        stopPreviewUseCase()
+        verify(exactly = 1) { audioMixerRepository.stopPreview() }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/UnMuteTrackUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/UnMuteTrackUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.UnMuteTrackUseCase
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class UnMuteTrackUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var unMuteTrackUseCase: UnMuteTrackUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        unMuteTrackUseCase = UnMuteTrackUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls unMuteTrack on repository`() {
+        val trackId = 1L
+        unMuteTrackUseCase(trackId)
+        verify(exactly = 1) { audioMixerRepository.unMuteTrack(trackId) }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/UndoEffectUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/UndoEffectUseCaseTest.kt
@@ -1,0 +1,33 @@
+package com.android.harmoniatpi.domain.usecases
+
+import com.android.harmoniatpi.domain.interfaces.AudioMixerRepository
+import com.android.harmoniatpi.domain.usecases.audioUseCases.UndoEffectUseCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UndoEffectUseCaseTest {
+
+    private lateinit var audioMixerRepository: AudioMixerRepository
+    private lateinit var useCase: UndoEffectUseCase
+
+    @Before
+    fun setUp() {
+        audioMixerRepository = mockk(relaxed = true)
+        useCase = UndoEffectUseCase(audioMixerRepository)
+    }
+
+    @Test
+    fun `invoke calls undoEffect on repository and returns success`() {
+        val trackId = 1L
+        every { audioMixerRepository.undoEffect(trackId) } returns Result.success(Unit)
+
+        val result = useCase(trackId)
+
+        verify(exactly = 1) { audioMixerRepository.undoEffect(trackId) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/DeleteProjectFromFirestoreUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/DeleteProjectFromFirestoreUseCaseTest.kt
@@ -1,0 +1,33 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DeleteProjectFromFirestoreUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: DeleteProjectFromFirestoreUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = DeleteProjectFromFirestoreUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls deleteProjectFromFirestore on repository`() = runTest {
+        val projectId = "project123"
+        coEvery { repository.deleteProjectFromFirestore(projectId) } returns Result.success(Unit)
+
+        val result = useCase(projectId)
+
+        coVerify(exactly = 1) { repository.deleteProjectFromFirestore(projectId) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/GetProjectByIdFromFirestoreUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/GetProjectByIdFromFirestoreUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import com.android.harmoniatpi.domain.model.project.Project
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetProjectByIdFromFirestoreUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: GetProjectByIdFromFirestoreUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = GetProjectByIdFromFirestoreUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls getProjectByIdFromFirestore on repository`() = runTest {
+        val projectId = "project123"
+        val mockProject = mockk<Project>()
+        coEvery { repository.getProjectByIdFromFirestore(projectId) } returns mockProject
+
+        val result = useCase(projectId)
+
+        coVerify(exactly = 1) { repository.getProjectByIdFromFirestore(projectId) }
+        assertEquals(mockProject, result)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/GetUserOnFirebaseByIDUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/GetUserOnFirebaseByIDUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import com.android.harmoniatpi.domain.model.UserPreferences
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetUserOnFirebaseByIDUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: GetUserOnFirebaseByIDUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = GetUserOnFirebaseByIDUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls getUserById on repository`() = runTest {
+        val userId = "user123"
+        val mockUser = mockk<UserPreferences>()
+
+        coEvery { repository.getUserById(userId) } returns mockUser
+
+        val result = useCase(userId)
+
+        coVerify(exactly = 1) { repository.getUserById(userId) }
+
+        assertEquals(mockUser, result)
+    }
+
+    @Test
+    fun `invoke calls getUserById on repository and handles failure`() = runTest {
+        val userId = "user123"
+
+        coEvery { repository.getUserById(userId) } returns null
+
+        val result = useCase(userId)
+
+        coVerify(exactly = 1) { repository.getUserById(userId) }
+
+        assertEquals(null, result)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/LogOutFirebaseUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/LogOutFirebaseUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class LogOutFirebaseUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: LogOutFirebaseUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = LogOutFirebaseUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls logOutUser on repository`() = runTest {
+        useCase()
+        coVerify(exactly = 1) { repository.logOutUser() }
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/LoginWithGoogleUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/LoginWithGoogleUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import com.google.firebase.auth.FirebaseUser
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class LoginWithGoogleUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: LoginWithGoogleUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = LoginWithGoogleUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls signInWithGoogle on repository`() = runTest {
+        val idToken = "googleToken123"
+        val mockUser = mockk<FirebaseUser>()
+        coEvery { repository.signInWithGoogle(idToken) } returns Result.success(mockUser)
+
+        val result = useCase(idToken)
+
+        coVerify(exactly = 1) { repository.signInWithGoogle(idToken) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/RegisterUserFirebaseUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/RegisterUserFirebaseUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RegisterUserFirebaseUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var useCase: RegisterUserFirebaseUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        useCase = RegisterUserFirebaseUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls registerUserFirebase on repository`() = runTest {
+        val email = "test@example.com"
+        val pass = "123456"
+        val name = "Test"
+        val lastName = "User"
+        coEvery { repository.registerUserFirebase(email, pass, name, lastName) } returns Result.success(mockk())
+
+        val result = useCase(email, pass, name, lastName)
+
+        coVerify(exactly = 1) { repository.registerUserFirebase(email, pass, name, lastName) }
+        assertTrue(result.isSuccess)
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/UpsertProjectInFirestoreUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/firebaseUseCases/UpsertProjectInFirestoreUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.android.harmoniatpi.domain.usecases.firebaseUseCases
+
+import com.android.harmoniatpi.data.local.model.ProjectFirebaseModel
+import com.android.harmoniatpi.domain.interfaces.Repository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UpsertProjectInFirestoreUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var upsertProjectInFirestoreUseCase: UpsertProjectInFirestoreUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        upsertProjectInFirestoreUseCase = UpsertProjectInFirestoreUseCase(repository)
+    }
+
+    @Test
+    fun `invoke calls upsertProjectInFirestore on repository`() = runTest {
+        
+        val projectModel = mockk<ProjectFirebaseModel>()
+        coEvery { repository.upsertProjectInFirestore(projectModel) } returns Result.success(Unit)
+
+        
+        val result = upsertProjectInFirestoreUseCase(projectModel)
+
+        
+        coVerify(exactly = 1) { repository.upsertProjectInFirestore(projectModel) }
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `invoke returns failure when repository fails`() = runTest {
+        
+        val projectModel = mockk<ProjectFirebaseModel>()
+        val exception = Exception("Firestore error")
+        coEvery { repository.upsertProjectInFirestore(projectModel) } returns Result.failure(exception)
+
+        
+        val result = upsertProjectInFirestoreUseCase(projectModel)
+
+        
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/app/src/test/java/com/android/harmoniatpi/domain/usecases/roomUseCases/GetUserPreferencesUseCaseTest.kt
+++ b/app/src/test/java/com/android/harmoniatpi/domain/usecases/roomUseCases/GetUserPreferencesUseCaseTest.kt
@@ -1,0 +1,42 @@
+package com.android.harmoniatpi.domain.usecases.roomUseCases
+
+import com.android.harmoniatpi.domain.interfaces.Repository
+import com.android.harmoniatpi.domain.model.UserPreferences
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetUserPreferencesUseCaseTest {
+
+    private lateinit var repository: Repository
+    private lateinit var getUserPreferencesUseCase: GetUserPreferencesUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        getUserPreferencesUseCase = GetUserPreferencesUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns user preferences from repository`() = runTest {
+
+        val mockPreferences = mockk<UserPreferences>()
+        coEvery { repository.getUserPreferences() } returns mockPreferences
+
+        val result = getUserPreferencesUseCase()
+
+        assertEquals(mockPreferences, result)
+    }
+
+    @Test
+    fun `invoke returns null when repository returns null`() = runTest {
+        coEvery { repository.getUserPreferences() } returns null
+
+        val result = getUserPreferencesUseCase()
+
+        assertEquals(null, result)
+    }
+}


### PR DESCRIPTION
# Resumen de cambios

Se sumaron pruebas de test al AudioMixerRepositoryImplTest, además se agregaron los parámetros necesarios para que los tests implementados en un principio funcionen correctamente. También se testearon los siguientes casos de uso:



- MuteTrackUseCaseTest.kt

- SetTrackVolumeUseCaseTest.kt

- GetUserPreferencesUseCaseTest.kt

- UpsertProjectInFirestoreUseCaseTest.kt

- CheckIsInternetAvailableUseCaseTest.kt

- UnMuteTrackUseCaseTest.kt

- PlayPreviewUseCaseTest.kt

- StopPreviewUseCaseTest.kt

- SeekToUseCaseTest.kt

- SetTrackOffsetUseCaseTest.kt

- SetTrackPlaybackRangeUseCaseTest.kt

- GetCurrentPlaybackPositionUseCaseTest.kt

- OnPreviewCompletedUseCaseTest.kt

- CutAudioSegmentUseCaseTest.kt

- UndoEffectUseCaseTest.kt

- AddTrackFromSegmentUseCaseTest.kt

- AddTrackFromFileUseCaseTest.kt

- ApplyDelayEffectUseCaseTest.kt

- ApplyFlangerEffectUseCaseTest.kt

- ApplyHighPassFilterUseCaseTest.kt

- DeleteProjectFromFirestoreUseCaseTest.kt

- LoginWithGoogleUseCaseTest.kt

- RegisterUserFirebaseUseCaseTest.kt

- LogOutFirebaseUseCaseTest.kt

- GetProjectByIdFromFirestoreUseCaseTest.kt
