### PR TITLE
Agregado de mensaje de error de credenciales

### DIFF
--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/loginScreen/LoginScreen.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/loginScreen/LoginScreen.kt
@@ -121,6 +121,13 @@ fun LoginScreen(
                     Column(modifier = Modifier.weight(2f)) {
                         Box(modifier = Modifier.weight(0.1f)) {
                             ScreenTitle("Inicia Sesión")
+                            uiState.errorMessage?.let {
+                                Text(
+                                    text = it,
+                                    color = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.align(Alignment.CenterStart).padding(top = 24.dp)
+                                )
+                            }
                         }
                         Box(modifier = Modifier.weight(0.5f)) {
                             LoginForm(

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/loginScreen/viewModel/LoginScreenViewModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/loginScreen/viewModel/LoginScreenViewModel.kt
@@ -91,7 +91,7 @@ class LoginScreenViewModel @Inject constructor(
                             _uiState.update {
                                 it.copy(
                                     isLoading = false,
-                                    errorMessage = e.message ?: "Error de autenticación"
+                                    errorMessage = "Error de autenticación"
                                 )
                             }
                         }


### PR DESCRIPTION
Se añade un mensaje de error por debajo del título del formulario de login
<img width="354" height="607" alt="image" src="https://github.com/user-attachments/assets/d0086094-da4b-413e-8944-b2016368bb6c" />
