### PR TITLE
Implementación de permisos de clonado en publicaciones

### DIFF
--- a/app/src/main/java/com/android/harmoniatpi/data/database/entities/MyPostEntity.kt
+++ b/app/src/main/java/com/android/harmoniatpi/data/database/entities/MyPostEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.android.harmoniatpi.di.util.JsonUtils
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 import com.android.harmoniatpi.domain.model.userPreferences.Comment
 import com.android.harmoniatpi.domain.model.userPreferences.Post
 
@@ -50,6 +51,8 @@ data class MyPostEntity(
     val hasNewLike: Boolean = false,
     @ColumnInfo(name = "hasNewClone", defaultValue = "0")
     val hasNewClone: Boolean = false,
+    @ColumnInfo(name = "cloningAccess", defaultValue = "0")
+    val cloningAccess: CloningAccess = CloningAccess.PUBLIC
 ) {
     fun toDomain(jsonUtils: JsonUtils) = Post(
         id = id,
@@ -71,6 +74,7 @@ data class MyPostEntity(
         clonedOption = clonedOption,
         hasNewComment = hasNewComment,
         hasNewLike = hasNewLike,
-        hasNewClone = hasNewClone
+        hasNewClone = hasNewClone,
+        cloningAccess = cloningAccess
     )
 }

--- a/app/src/main/java/com/android/harmoniatpi/data/local/model/PostFirebaseModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/data/local/model/PostFirebaseModel.kt
@@ -1,6 +1,7 @@
 package com.android.harmoniatpi.data.local.model
 
 import com.android.harmoniatpi.di.util.JsonUtils
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 import com.android.harmoniatpi.domain.model.userPreferences.Post
 
 data class PostFirebaseModel(
@@ -20,7 +21,8 @@ data class PostFirebaseModel(
     val likes: Int = 0,
     val comments: List<CommentFirebaseModel> = emptyList(),
     val totalShared: Int = 0,
-    val clonedOption: Boolean = false
+    val clonedOption: Boolean = false,
+    val cloningAccess: CloningAccess = CloningAccess.PUBLIC
 ) {
     fun toDomain(jsonUtils: JsonUtils): Post {
         return Post(
@@ -40,7 +42,8 @@ data class PostFirebaseModel(
             likes = likes,
             comments = comments.map { it.toDomain() },
             totalShared = totalShared,
-            clonedOption = clonedOption
+            clonedOption = clonedOption,
+            cloningAccess = cloningAccess
         )
     }
 }

--- a/app/src/main/java/com/android/harmoniatpi/domain/model/project/CloningAccess.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/model/project/CloningAccess.kt
@@ -1,0 +1,6 @@
+package com.android.harmoniatpi.domain.model.project
+
+enum class CloningAccess {
+    PUBLIC,
+    FOLLOWERS_ONLY
+}

--- a/app/src/main/java/com/android/harmoniatpi/domain/model/userPreferences/Post.kt
+++ b/app/src/main/java/com/android/harmoniatpi/domain/model/userPreferences/Post.kt
@@ -3,6 +3,7 @@ package com.android.harmoniatpi.domain.model.userPreferences
 import com.android.harmoniatpi.data.database.entities.MyPostEntity
 import com.android.harmoniatpi.data.local.model.PostFirebaseModel
 import com.android.harmoniatpi.di.util.JsonUtils
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 
 data class Post(
     val id: String,
@@ -24,7 +25,8 @@ data class Post(
     val clonedOption: Boolean = false,
     val hasNewComment: Boolean = false,
     val hasNewLike: Boolean = false,
-    val hasNewClone : Boolean = false
+    val hasNewClone : Boolean = false,
+    val cloningAccess: CloningAccess = CloningAccess.PUBLIC
 ) {
     fun toPostFirebaseModel(jsonUtils: JsonUtils): PostFirebaseModel {
         return PostFirebaseModel(
@@ -44,7 +46,8 @@ data class Post(
             likes = likes,
             comments = comments.map { it.toCommentFirebaseModel() },
             totalShared = totalShared,
-            clonedOption = clonedOption
+            clonedOption = clonedOption,
+            cloningAccess = cloningAccess
         )
     }
 
@@ -73,6 +76,7 @@ data class Post(
         clonedOption = clonedOption,
         hasNewComment = hasNewComment,
         hasNewLike = hasNewLike,
-        hasNewClone = hasNewClone
+        hasNewClone = hasNewClone,
+        cloningAccess = cloningAccess
     )
 }

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/communityScreen/components/PostCard.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/communityScreen/components/PostCard.kt
@@ -69,6 +69,7 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import coil.compose.AsyncImage
 import com.android.harmoniatpi.R
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 import com.android.harmoniatpi.domain.model.userPreferences.Post
 import com.android.harmoniatpi.ui.components.ShowConfirmationDialog
 import com.android.harmoniatpi.ui.screens.homeScreen.tabs.communityScreen.util.sharePost
@@ -91,8 +92,16 @@ fun PostCard(
     onCloneClicked: () -> Unit,
     viewUserProfile: (String) -> Unit,
     isCloningThisPost: Boolean,
-    isFriend: Boolean
+    isFriend: Boolean,
 ) {
+
+    val showCloneButton = remember(post.cloningAccess, isFriend) {
+        when (post.cloningAccess) {
+            CloningAccess.PUBLIC -> true // Si es público, se muestra a todos
+            CloningAccess.FOLLOWERS_ONLY -> isFriend // Si es privado, solo si es amigo (seguidor)
+        }
+    }
+
     val postAudio = post.urlCompleteAudio
     val context = LocalContext.current
     var isPlaying by remember { mutableStateOf(false) }
@@ -317,9 +326,9 @@ fun PostCard(
 
 
                             // 2. Clonar
-                            if (post.idProject.isNotBlank() && post.clonedOption == true && isFriend) {
-                                val isCloneEnabled =
-                                    !isAlreadyCloned && !isMyPost && !isCloningThisPost
+                            if (post.idProject.isNotBlank() && post.clonedOption == true && showCloneButton) {
+                                val isCloneEnabled = !isAlreadyCloned && !isMyPost && !isCloningThisPost
+
                                 if (isCloningThisPost) {
                                     Box(
                                         modifier = Modifier.padding(

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/CloningAccessSelector.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/CloningAccessSelector.kt
@@ -1,0 +1,42 @@
+package com.android.harmoniatpi.ui.screens.homeScreen.tabs.projectsScreen.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.android.harmoniatpi.domain.model.project.CloningAccess
+
+@Composable
+fun CloningAccessSelector(
+    selectedOption: CloningAccess,
+    onOptionSelected: (CloningAccess) -> Unit
+) {
+    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+        Text(
+            text = "Permisos de Clonado",
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Row (verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(
+                selected = selectedOption == CloningAccess.PUBLIC,
+                onClick = { onOptionSelected(CloningAccess.PUBLIC) }
+            )
+            Text("Público (Todos)")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(
+                selected = selectedOption == CloningAccess.FOLLOWERS_ONLY,
+                onClick = { onOptionSelected(CloningAccess.FOLLOWERS_ONLY) }
+            )
+            Text("Solo Seguidores")
+        }
+    }
+}

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/PublishOriginalDialog.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/PublishOriginalDialog.kt
@@ -1,5 +1,7 @@
 package com.android.harmoniatpi.ui.screens.homeScreen.tabs.projectsScreen.components
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -7,8 +9,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 import com.android.harmoniatpi.domain.model.project.Project
 import com.android.harmoniatpi.ui.screens.homeScreen.tabs.projectsScreen.viewmodel.ProjectViewModel
 
@@ -27,7 +32,7 @@ fun PublishOriginalDialog(
     var postHashtags by remember { mutableStateOf(project.hashtags.joinToString(", ")) }
     var postImageUrl by remember(project) { mutableStateOf(project.imageUrl) }
     var isPublishing by remember { mutableStateOf(false) }
-
+    var cloningAccess by remember { mutableStateOf(CloningAccess.PUBLIC) }
     BasePublishDialog(
         dialogTitle = "Publicar Proyecto",
         isPublishing = isPublishing,
@@ -42,6 +47,7 @@ fun PublishOriginalDialog(
                 postDescription = postDescription,
                 postHashtags = postHashtags,
                 postImageUrl = postImageUrl,
+                cloningAccess = cloningAccess,
                 onComplete = {
                     isPublishing = false
                     onDismiss()
@@ -70,6 +76,11 @@ fun PublishOriginalDialog(
                 onValueChange = { postDescription = it },
                 placeholder = "Describe tu publicación...",
                 textStyle = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            CloningAccessSelector(
+                selectedOption = cloningAccess,
+                onOptionSelected = { cloningAccess = it }
             )
         }
     }

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/viewmodel/ProjectViewModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/viewmodel/ProjectViewModel.kt
@@ -10,6 +10,7 @@ import com.android.harmoniatpi.di.util.JsonUtils
 import com.android.harmoniatpi.domain.cache.HoloJamCache
 import com.android.harmoniatpi.domain.model.UserPreferences
 import com.android.harmoniatpi.domain.model.project.AudioTrack
+import com.android.harmoniatpi.domain.model.project.CloningAccess
 import com.android.harmoniatpi.domain.model.project.Project
 import com.android.harmoniatpi.domain.model.userPreferences.Post
 import com.android.harmoniatpi.domain.usecases.GetProjectByIdUseCase
@@ -449,6 +450,7 @@ class ProjectViewModel @Inject constructor(
         postDescription: String,
         postHashtags: String,
         postImageUrl: String?,
+        cloningAccess: CloningAccess,
         onComplete: () -> Unit
     ) {
 
@@ -470,7 +472,7 @@ class ProjectViewModel @Inject constructor(
                 // El 'project.title' no lo cambiamos aquí.
                 description = postDescription,
                 hashtags = postHashtags.split(",").map { it.trim() },
-                imageUrl = postImageUrl
+                imageUrl = postImageUrl,
             )
             // --- 2. GUARDAR CAMBIOS EN ROOM ---
             try {
@@ -662,7 +664,8 @@ class ProjectViewModel @Inject constructor(
                     likes = 0,
                     totalShared = 0,
                     comments = emptyList(),
-                    clonedOption = true
+                    clonedOption = true,
+                    cloningAccess = cloningAccess
                 )
                 insertNewPostFirebaseDataBaseUseCase(post)
                 Log.i("ProjectViewModel", "Post creado en Firebase Realtime DB para ${project.id}")


### PR DESCRIPTION
- Se crea el enum `CloningAccess` (PUBLIC, FOLLOWERS_ONLY) y se añade la propiedad a los modelos `Post`, `MyPostEntity` y `PostFirebaseModel`.
- Se implementa el componente `CloningAccessSelector` y se integra en `PublishOriginalDialog` para definir la privacidad al publicar un proyecto.
- Se actualiza `ProjectViewModel` para procesar y guardar el nivel de acceso de clonado seleccionado.
- Se ajusta la lógica de visualización en `PostCard` para ocultar el botón de clonar si el acceso está restringido a seguidores y el usuario no cumple la condición.