### PR TITLE
feat: Navegación a la gestión del proyecto tras su creación

### DIFF
--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/ProjectsScreen.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/ProjectsScreen.kt
@@ -211,6 +211,9 @@ fun ProjectsScreen(
             uiState = uiState,
             viewModel = viewModel,
             onDismiss = { showCreateForm = false /* viewModel.dismissCreateDialog() */ },
+            onNavigateToManagement = {
+                onNavigateToProjectManagementScreen()
+            }
         )
     }
 

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/CreateProjectDialog.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/components/CreateProjectDialog.kt
@@ -11,7 +11,8 @@ import com.android.harmoniatpi.ui.screens.homeScreen.tabs.projectsScreen.viewmod
 fun CreateProjectDialog(
     uiState: ProjectUiState,
     viewModel: ProjectViewModel,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onNavigateToManagement: () -> Unit,
 ) {
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -28,6 +29,7 @@ fun CreateProjectDialog(
                 onSuccess = {
                     Toast.makeText(context, "Proyecto guardado", Toast.LENGTH_SHORT).show()
                     onDismiss()
+                    onNavigateToManagement()
                 },
                 onError = { error ->
                     Toast.makeText(context, "Error: $error", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/viewmodel/ProjectViewModel.kt
+++ b/app/src/main/java/com/android/harmoniatpi/ui/screens/homeScreen/tabs/projectsScreen/viewmodel/ProjectViewModel.kt
@@ -429,6 +429,7 @@ class ProjectViewModel @Inject constructor(
 
                 insertProjectInDBUseCase(project)
 
+                setCurrentProject(project)
 
                 _uiState.update {
                     it.copy(


### PR DESCRIPTION
Al crear un nuevo proyecto, el usuario ahora es redirigido automáticamente a la pantalla de gestión de dicho proyecto.

Cambios principales:
- Se modifica el `CreateProjectDialog` para que, en caso de éxito, invoque una nueva función `onNavigateToManagement`.
- En `ProjectsScreen`, se pasa la función de navegación a `CreateProjectDialog`.
- El `ProjectViewModel` ahora establece el proyecto recién creado como el proyecto actual (`setCurrentProject`) para asegurar que la pantalla de gestión muestre el proyecto correcto.